### PR TITLE
uwsgi docs

### DIFF
--- a/website/docs/advanced/troubleshooting.md
+++ b/website/docs/advanced/troubleshooting.md
@@ -28,3 +28,6 @@ Please, **do not load test** the ConfigCat production infrastructure without our
 ## Too many requests error in Angular
 The problem was with Angular's Hot Module Replacement functionality during development. The wrapper class, which contained the auto polling ConfigCat SDK was edited, and the Hot Module Replacement reinitialized the whole class without releasing the old, replaced module's Auto Polling timer.
 We believe that this is a really rare case, it could happen only during development.
+
+## Python Auto polling issue with uWSGI web server
+The Python SDK's Auto polling mode utilizes its polling job in a `threading.Thread` object. If you are running your application behind an uWSGI web server, the auto polling mode may not work as expected, because the uWSGI web server disables Python's threading by default. Please [enable threading](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#enable-threads) or switch to another polling mode in this case.

--- a/website/docs/sdk-reference/python.md
+++ b/website/docs/sdk-reference/python.md
@@ -123,6 +123,10 @@ Available options:
 | `max_init_wait_time_seconds`        | Maximum waiting time between the client initialization and the first config acquisition in secconds. | 5       |
 | `config_cache_class`                | Custom cache implementation.                                                                         | None    |
 
+:::caution
+Auto polling mode utilizes its polling job in a `threading.Thread` object. If you are running your application behind an uWSGI web server, the auto polling mode may not work as expected, because the uWSGI web server disables Python's threading by default. Please [enable threading](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#enable-threads) or switch to another polling mode in this case.
+:::
+
 ### Lazy loading
 When calling `get_value()` the *ConfigCat SDK* downloads the latest setting values if they are not present or expired in the cache. In this case the `get_value()` will return the setting value after the cache is updated.
 


### PR DESCRIPTION
### Description

Python SDK's auto polling mode may not work with uWSGI web server. I added some not to the python sdk's docs and to the troubleshooting section too.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
