### PR TITLE
Absolute links, trailing slash fiesta

### DIFF
--- a/website/docs/advanced/team-management/auto-assign-users.md
+++ b/website/docs/advanced/team-management/auto-assign-users.md
@@ -3,7 +3,7 @@ id: auto-assign-users
 title: Auto-assign Users
 ---
 
-All new users who sign up with a [verified email domain](./domain-verification) will be automatically added to your organization.
+All new users who sign up with a [verified email domain](/docs/advanced/team-management/domain-verification) will be automatically added to your organization.
 Furthermore, you can also set which Organization roles / Product permissions they should get upon on-boarding.
 
 #### Steps to configure:

--- a/website/docs/advanced/team-management/domain-verification.md
+++ b/website/docs/advanced/team-management/domain-verification.md
@@ -3,7 +3,7 @@ id: domain-verification
 title: Domain Verification
 ---
 
-In order to use the [SAML Single Sign-On](./saml/saml-overview) and the [Auto-assign Users](./auto-assign-users) features, you have to verify the ownership of the domain that your company uses for email addresses.
+In order to use the [SAML Single Sign-On](/docs/advanced/team-management/saml/saml-overview) and the [Auto-assign Users](/docs/advanced/team-management/auto-assign-users) features, you have to verify the ownership of the domain that your company uses for email addresses.
 
 #### Steps to verify your domain:
 

--- a/website/docs/advanced/team-management/saml/identity-providers/adfs.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/adfs.md
@@ -176,4 +176,4 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
 
 ### 6. Next Steps
 
-- Configure the [auto-assignment of users](../../auto-assign-users).
+- Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/auth0.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/auth0.md
@@ -105,4 +105,4 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
 
 ### 5. Next Steps
 
-- Configure the [auto-assignment of users](../../auto-assign-users).
+- Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/azure-ad.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/azure-ad.md
@@ -118,4 +118,4 @@ To let users authenticate via SAML, you need to assign individual users or group
 
 ### 6. Next Steps
 
-- Configure the [auto-assignment of users](../../auto-assign-users).
+- Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/google.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/google.md
@@ -98,4 +98,4 @@ The next step will guide you on how to configure the Google App with details pro
 
 ### 5. Next Steps
 
-- Configure the [auto-assignment of users](../../auto-assign-users).
+- Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/okta.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/okta.md
@@ -118,4 +118,4 @@ To let users authenticate via SAML, you need to assign individual users or group
 
 ### 6. Next Steps
 
-- Configure the [auto-assignment of users](../../auto-assign-users).
+- Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/onelogin.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/onelogin.md
@@ -146,4 +146,4 @@ To let users authenticate via SAML, you need to assign the newly created applica
 
 ### 6. Next Steps
 
-- Configure the [auto-assignment of users](../../auto-assign-users).
+- Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/overview.md
+++ b/website/docs/advanced/team-management/saml/overview.md
@@ -8,19 +8,19 @@ This section describes how you can enable SAML Single Sign-On (SSO) for your Con
 SAML SSO allows your team members to sign up and log in to ConfigCat via their company accounts using your own Identity Provider (IdP).
 
 ### Prerequisites
-- [Verified domain](../domain-verification)  
+- [Verified domain](/docs/advanced/team-management/domain-verification)  
   In order to configure SAML, you have to verify the ownership of the domain that your company uses for email addresses. This step is required, because at the beginning of the login process, we use the user's email domain to select the appropriate SAML Identity Provider. 
 - Identity Provider that supports SAML 2.0
 
 ### Configure a SAML Identity Provider
 
 We tested and validated the following SAML Identity Providers:
-- [Azure AD](identity-providers/azure-ad)
-- [ADFS](identity-providers/adfs)
-- [Google](identity-providers/google)
-- [Okta](identity-providers/okta)
-- [Auth0](identity-providers/auth0)
-- [OneLogin](identity-providers/onelogin)
+- [Azure AD](/docs/advanced/team-management/saml/identity-providers/azure-ad)
+- [ADFS](/docs/advanced/team-management/saml/identity-providers/adfs)
+- [Google](/docs/advanced/team-management/saml/identity-providers/google)
+- [Okta](/docs/advanced/team-management/saml/identity-providers/okta)
+- [Auth0](/docs/advanced/team-management/saml/identity-providers/auth0)
+- [OneLogin](/docs/advanced/team-management/saml/identity-providers/onelogin)
 
 :::info
 Other Identity Providers might also work with ConfigCat, if they support the SAML 2.0 protocol.


### PR DESCRIPTION
### Description

Nginx puts a trailing slash which breaks the page links on subpages. So, I used absolute paths instead.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
