### PR TITLE
logging fix on elixir sdk page

### DIFF
--- a/website/docs/sdk-reference/elixir.md
+++ b/website/docs/sdk-reference/elixir.md
@@ -364,10 +364,10 @@ In the *ConfigCat SDK*, we use the default Elixir's [Logger](https://hexdocs.pm/
 Info level logging helps to inspect how a feature flag was evaluated:
 
 ```bash
-[info]  Evaluating get_value('isPOCFeatureEnabled').
-[info]  User object: %ConfigCat.User{country: nil, custom: %{}, email: "configcat@example.com", identifier: "435170f4-8a8b-4b67-a723-505ac7cdea92"}
-[info]  Evaluating rule: [Email:configcat@example.com] [CONTAINS] [@something.com] => no match
-[info]  Evaluating rule: [Email:configcat@example.com] [CONTAINS] [@example.com] => match, returning: true
+[debug]  Evaluating get_value('isPOCFeatureEnabled').
+[debug]  User object: %ConfigCat.User{country: nil, custom: %{}, email: "configcat@example.com", identifier: "435170f4-8a8b-4b67-a723-505ac7cdea92"}
+[debug]  Evaluating rule: [Email:configcat@example.com] [CONTAINS] [@something.com] => no match
+[debug]  Evaluating rule: [Email:configcat@example.com] [CONTAINS] [@example.com] => match, returning: true
 ```
 
 ## `get_all_keys()`


### PR DESCRIPTION
### Description

In the elixir sdk evaluation logs moved back to debug level. We updated the samples in the docs too.

### Testing guide

Evaluation log example's  loglevel should be debug.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
