### PR TITLE
docs: Typo on `pollIntervalSeconds` docs

### DIFF
--- a/website/docs/sdk-reference/node.md
+++ b/website/docs/sdk-reference/node.md
@@ -187,7 +187,7 @@ The *ConfigCat SDK* downloads the latest values and stores them automatically ev
 
 | Option Parameter      | Description                                                                                                                | Default        |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `pollIntervalSeconds` | Polling interval. Range: `1 - Number.MAX_SAFE_INTEGER`                                                                     | 60             |
+| `pollIntervalSeconds` | Polling interval. Range: `[1, Number.MAX_SAFE_INTEGER]`                                                                     | 60             |
 | `configChanged`       | Callback to get notified about changes.                                                                                    | -              |
 | `logger`              | Custom logger. See below for details.                                                                                      | Console logger |
 | `requestTimeoutMs`    | The amount of milliseconds the SDK waits for a response from the ConfigCat servers before returning values from the cache. | 30000          |


### PR DESCRIPTION
### Related tickets

None.

### Description

Reading the docs for node I found that the `pollIntervalSeconds` range was actually `[-Number.MAX_SAFE_INTEGER+1, 1]` instead of the (as I understand) the desirable range: `[1, Number.MAX_SAFE_INTEGER]`.

### Testing guide

No applicable.

### Requirement checklist

- [X] I have validated my changes on a test/local environment.
- [X] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [X] (Optional) I have updated outdated packages.
