### PR TITLE
Add type hints to PHP custom cache implementation

### DIFF
--- a/website/docs/sdk-reference/php.md
+++ b/website/docs/sdk-reference/php.md
@@ -311,12 +311,12 @@ You can use the following caching options:
   ```php
   class CustomCache extends \ConfigCat\Cache\ConfigCache
   { 
-      protected function get($key)
+      protected function get($key): ?string
       {
           // load from cache
       } 
     
-      protected function set($key, $value)
+      protected function set($key, $value): void
       {
           // save into cache
       }


### PR DESCRIPTION
### Description

Add type hints to PHP custom cache implementation.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
