### PR TITLE
compile is now deprecated and removed completely Gradle 7+

### DIFF
--- a/website/docs/sdk-reference/java.md
+++ b/website/docs/sdk-reference/java.md
@@ -20,9 +20,13 @@ Maven:
   <version>[7.0.0,)</version>
 </dependency>
 ```
-Gradle:
+Old Gradle versions:
 ```bash
 compile group: 'com.configcat', name: 'configcat-java-client', version: '7.+'
+```
+Gradle 7 and above:
+```bash
+implementation group: 'com.configcat', name: 'configcat-java-client', version: '7.+'
 ```
 ### 2. Import the ConfigCat SDK
 ```java

--- a/website/docs/sdk-reference/java.md
+++ b/website/docs/sdk-reference/java.md
@@ -20,13 +20,10 @@ Maven:
   <version>[7.0.0,)</version>
 </dependency>
 ```
-Old Gradle versions:
+
+Gradle:
 ```bash
-compile group: 'com.configcat', name: 'configcat-java-client', version: '7.+'
-```
-Gradle 7 and above:
-```bash
-implementation group: 'com.configcat', name: 'configcat-java-client', version: '7.+'
+implementation 'com.configcat:configcat-java-client:7.+'
 ```
 ### 2. Import the ConfigCat SDK
 ```java


### PR DESCRIPTION

### Description

Our CW Roxana Halati caught this while playing around with feature flags in Java. 


### Requirement checklist

- [ ] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
