### PR TITLE
Updated editUrl variable

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -177,7 +177,7 @@ module.exports = {
           sidebarCollapsible: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/configcat/docs/edit/master/website/',
+            'https://github.com/configcat/docs/tree/master/website',
           routeBasePath: '/'
         },
         gtag: {


### PR DESCRIPTION
### Description

Updated `editUrl` variable in `docusaurus.config.js` to a readable link (Removing edit from the link)
When this PR is merged:

The **Edit this page** link on each page will be changed as follows:

**Before**: https://github.com/configcat/docs/edit/master/website/docs/sdk-reference/kotlin.md (Requires GitHub Auth)
**After**: https://github.com/configcat/docs/blob/master/website/docs/sdk-reference/kotlin.md (Does not require Auth)

**Reason for change**: Because accessing the edit link requires GitHub authentication, SE Ranking reports its as a 429 error when it audits the page as shown below:

![image](https://user-images.githubusercontent.com/74829200/200006657-6fd6ee60-53bc-463b-9fb8-dca4d67464cb.png)

As a side note, this edit link can also be hidden from each page by removing the `editUrl` variable from `docusaurus.config.js` as mentioned here: [https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl)

![image](https://user-images.githubusercontent.com/74829200/200008686-c21d9809-a653-48a0-aa6e-6cdec8b9da06.png)

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
