### PR TITLE
Remove duplicate h1s

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -10,19 +10,19 @@ This page is an overview and a short guide on how to get started.
 
 You can use it with many similar techniques such as feature flags/toggles, canary releases, soft launches, A-B testing, remote configuration management, and phased rollouts. Configure your application and features even after deployment.
 
-# The birth of a Feature Flag
+## The birth of a Feature Flag
 
 First, **add a feature flag** on the _ConfigCat Dashboard_,
 then you can **connect your application** to the ConfigCat service to access your feature flag.
 
-## Create a feature flag on the _ConfigCat Dashboard_
+### Create a feature flag on the _ConfigCat Dashboard_
 
 1. <a href="https://app.configcat.com/login" target="_blank">Log in</a> to the _Dashboard_
 2. Click _ADD FEATURE FLAG_ and give it a name.
 
 <img src="/docs/assets/getting-started-1.png" className="zoomable" alt="getting-started" />
 
-## Connect your application
+### Connect your application
 
 There are ready to use code snippets for `.NET`, `Java`, `Android (Java)`, `Kotlin`, `iOS`, `Dart (Flutter)`, `Node`, `JavaScript`, `Python`, `Go`, `PHP`, `Elixir`, `C++` on the <a href="https://app.configcat.com" target="_blank">ConfigCat Dashboard</a>, just scroll down to the **SDK Key and steps to connect your application** section.
 

--- a/website/docs/requests.md
+++ b/website/docs/requests.md
@@ -16,9 +16,9 @@ Keep track of the number of config.json downloads your apps are making on the <a
 
 <img src="/docs/assets/stats.png" className="zoomable" alt="ConfigCat Statistics" />
 
-# Current config.json download limits
+## Current config.json download limits
 
-## Shared infrastructure
+### Shared infrastructure
 
 The following plans run on shared infrastructure. So all customers use the same API nodes and Config Delivery Network (CDN).
 
@@ -35,11 +35,11 @@ Use the <a href="https://configcat.com/calculator/" target="_blank">Plan Calcula
 If you hit this limit, we will keep your application up and running. However, you can expect us to contact you on how we can meet your needs.
 :::
 
-## Dedicated infrastructure
+### Dedicated infrastructure
 
 The following plans include dedicated API and CDN nodes.
 
-### Hosted
+#### Hosted
 
 Runs on dedicated servers provided by ConfigCat.
 The basic package includes:
@@ -52,7 +52,7 @@ The basic package includes:
 | **Basic package**             |   6,000,000,000 |        ~2400 |            ~4800 |
 | **Every additional CDN node** | + 1,000,000,000 |         ~400 |             ~800 |
 
-### On-Premise (Self-hosted)
+#### On-Premise (Self-hosted)
 
 Runs on the customer's own servers. We suggest <a href="https://configcat.com/support/" target="_blank">contacting ConfigCat's engineering</a>
 team on exact requirements and performance.


### PR DESCRIPTION
### Description

Remove duplicate H1s and fix heading hierarchy.

Reason for change: This was in the weekly SE Ranking audit report:

![image](https://user-images.githubusercontent.com/74829200/205079707-33fdcb71-6cfd-4723-93f2-d57674c1d5e3.png)

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
