### PR TITLE
Add missing h2 tags

### DIFF
--- a/website/docs/advanced/caching.md
+++ b/website/docs/advanced/caching.md
@@ -6,18 +6,18 @@ description: This section describes how to use the SDK's caching feature. There 
 
 There are 3 different ways (polling modes) to control caching.
 
-### Auto polling (default)
+## Auto polling (default)
 
 In auto polling mode, the ConfigCat SDK downloads the latest values automatically and stores them in the cache.
 This is done in every 60 seconds by default.
 You can set the polling interval to any number between 1 second and int max.
 
-### Lazy loading
+## Lazy loading
 
 In lazy loading mode, the ConfigCat SDK downloads the latest setting values only if they are not present in the cache, or if the cache has expired.
 You can set the cache Time To Live (TTL) to any number also.
 
-### Manual polling
+## Manual polling
 
 Manual polling gives you full control over when the `config.json` (with the setting values) is downloaded.
 The ConfigCat SDK will not download the `config.json` automatically.

--- a/website/docs/advanced/team-management/saml/overview.md
+++ b/website/docs/advanced/team-management/saml/overview.md
@@ -11,13 +11,13 @@ SAML SSO allows your team members to sign up and log in to ConfigCat via their c
 Go to the [Authentication Preferences](https://app.configcat.com/organization/authentication/) page to set up SAML SSO. You need to be an
 organization admin to do this.
 
-### Prerequisites
+## Prerequisites
 
 - [Verified domain](/docs/advanced/team-management/domain-verification)  
   In order to configure SAML, you have to verify the ownership of the domain that your company uses for email addresses. This step is required because, at the beginning of the login process, we use the user's email domain to select the appropriate SAML Identity Provider.
 - Identity Provider that supports SAML 2.0
 
-### Configure a SAML Identity Provider
+## Configure a SAML Identity Provider
 
 We tested and validated the following SAML Identity Providers:
 
@@ -32,12 +32,12 @@ We tested and validated the following SAML Identity Providers:
 Other Identity Providers might also work with ConfigCat, if they support the SAML 2.0 protocol.
 :::
 
-### Supported SAML flows
+## Supported SAML flows
 
 - Identity Provider initiated SSO
 - Service Provider initiated SSO
 
-### SAML Requirements
+## SAML Requirements
 
 These are the Identity Provider configuration requirements for ConfigCat:
 

--- a/website/docs/advanced/team-management/team-management-basics.md
+++ b/website/docs/advanced/team-management/team-management-basics.md
@@ -8,7 +8,7 @@ _Team members_ are your friends, colleagues, and clients who work on the same _P
 
 The following guide provides an overview of how to manage your team in ConfigCat.
 
-### Invite others to collaborate
+## Invite others to collaborate
 
 1. Click the `Invite Team Members` button on the sidebar.  
    <img src="/docs/assets/invite.png" className="zoomable" alt="Invite Button" />
@@ -18,37 +18,37 @@ The following guide provides an overview of how to manage your team in ConfigCat
 
 You can modify their permission group later anytime.
 
-### Managing Team Members (Product level)
+## Managing Team Members (Product level)
 
 You can manage your team on the <a href="https://app.configcat.com/product/members" target="_blank">Team Members page</a> of every Product.
 
 _Organization Admins_ have unlimited access to every Product under an Organization, their permissions can't be edited under the product. [Read more on Organization Management](/organization.md)
 
-### Managing Team Members (Organization level)
+## Managing Team Members (Organization level)
 
 Only _Organization Admins_ can manage Organization level permissions.
 
 To manage organization members, go to:
 [Organization Members & Roles page.](https://app.configcat.com/organization/members)
 
-### Permissions & Permission Groups (Product level)
+## Permissions & Permission Groups (Product level)
 
 _Permission groups_ are collections of permissions. They help you organize the permissions into groups that are meaningful to you. You can control your _Team members_ permissions by assigning them to _Permission groups_.
 
 Manage _Permission Groups_ on the [Permission Groups page](https://app.configcat.com/product/permission-groups) of every Product.
 
-### 2FA (Two-Factor Authentication)
+## 2FA (Two-Factor Authentication)
 
 Enforce 2FA for your team members to increase the security of your organization. Go to the [Authentication Preferences](https://app.configcat.com/organization/authentication/) page to enable 2FA. You need to be an organization admin to do this.
 
-### Auto-assign users
+## Auto-assign users
 
 All new users who sign up with a [verified email domain](/docs/advanced/team-management/domain-verification) can be automatically added to your organization.
 Furthermore, you can also set which Organization roles / Product permissions they should get upon on-boarding.
 
 Read more about [Auto-assigning users](/docs/advanced/team-management/auto-assign-users).
 
-### SSO (Single Sign-On)
+## SSO (Single Sign-On)
 
 You can let your organization members sign in to ConfigCat using 3rd party SSO (Single Sign-On) providers.
 

--- a/website/docs/sdk-reference/overview.md
+++ b/website/docs/sdk-reference/overview.md
@@ -8,81 +8,81 @@ The purpose of the SDKs are to download, cache feature flag values and to evalua
 
 Check out our language specific<a href="https://app.configcat.com/sdkkey" target="_blank"> Getting Started Guide</a> on how to connect your applications.
 
-### .NET, .NET Core
+## .NET, .NET Core
 
 - [Documentation](sdk-reference/dotnet.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/.net-sdk" target="_blank">GitHub repository of the ConfigCat .NET SDK.</a>
 
-### Java
+## Java
 
 - [Documentation](sdk-reference/java.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/java-sdk" target="_blank">GitHub repository of the ConfigCat Java SDK.</a>
 
-### JavaScript
+## JavaScript
 
 - [Documentation](sdk-reference/js.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/js-sdk" target="_blank">GitHub repository of the ConfigCat JavaScript SDK.</a>
 
-### JavaScript for Server-Side Rendered apps
+## JavaScript for Server-Side Rendered apps
 
 - [Documentation](sdk-reference/js-ssr.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/js-ssr-sdk" target="_blank">GitHub repository of the ConfigCat JS SSR SDK.</a>
 
-### React
+## React
 
 - [Documentation](sdk-reference/react.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/react-sdk" target="_blank">GitHub repository of the ConfigCat React SDK.</a>
 
-### Node.js
+## Node.js
 
 - [Documentation](sdk-reference/node.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/node-sdk" target="_blank">GitHub repository of the ConfigCat Node SDK.</a>
 
-### Android (Java)
+## Android (Java)
 
 - [Documentation](sdk-reference/android.md) on how to connect your application.
 - <a href="https://github.com/configcat/android-sdk" target="_blank">GitHub repository of the ConfigCat Android (Java) SDK.</a>
 
-### Kotlin Multiplatform
+## Kotlin Multiplatform
 
 - [Documentation](sdk-reference/kotlin.md) on how to connect your application.
 - <a href="https://github.com/configcat/kotlin-sdk" target="_blank">GitHub repository of the ConfigCat Kotlin Multiplatform SDK.</a>
 
-### iOS (Swift)
+## iOS (Swift)
 
 - [Documentation](sdk-reference/ios.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/swift-sdk" target="_blank">GitHub repository of the ConfigCat Swift SDK.</a>
 
-### Dart (Flutter)
+## Dart (Flutter)
 
 - [Documentation](sdk-reference/dart.md) on how to connect your application.
 - <a href="https://github.com/configcat/dart-sdk" target="_blank">GitHub repository of the ConfigCat Dart (Flutter) SDK.</a>
 
-### Python
+## Python
 
 - [Documentation](sdk-reference/python.md) on how to connect your application.
 - <a href="https://github.com/ConfigCat/python-sdk" target="_blank">GitHub repository of the ConfigCat Python SDK.</a>
 
-### Go
+## Go
 
 - [Documentation](sdk-reference/go.md) on how to connect your application.
 - <a href="https://github.com/configcat/go-sdk" target="_blank">GitHub repository of the ConfigCat Go SDK.</a>
 
-### PHP
+## PHP
 
 - [Documentation](sdk-reference/php.md) on how to connect your application.
 - <a href="https://github.com/configcat/php-sdk" target="_blank">GitHub repository of the ConfigCat PHP SDK.</a>
 
-### Ruby
+## Ruby
 
 - [Documentation](sdk-reference/ruby.md) on how to connect your application.
 - <a href="https://github.com/configcat/ruby-sdk" target="_blank">GitHub repository of the ConfigCat Ruby SDK.</a>
 
-### Elixir
+## Elixir
 
 - [Documentation](sdk-reference/elixir.md) on how to connect your application.
 - <a href="https://github.com/configcat/elixir-sdk" target="_blank">GitHub repository of the ConfigCat Elixir SDK.</a>
 
-### Deno (Community maintained)
+## Deno (Community maintained)
 
 - <a href="https://github.com/sigewuzhere/configcat-deno" target="_blank">GitHub repository of the ConfigCat Deno SDK.</a>


### PR DESCRIPTION
### Description

Added missing H2s to the following `.md` files in the docs. There are a few more `.md` files that should be fixed similarly. Treat this as a first PR.

- website/docs/advanced/team-management/team-management-basics.md
- website/docs/advanced/caching.md
- website/docs/advanced/team-management/saml/overview.md
- website/docs/sdk-reference/overview.md

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
