### PR TITLE
Add missing h2s

### DIFF
--- a/website/docs/advanced/team-management/auto-assign-users.md
+++ b/website/docs/advanced/team-management/auto-assign-users.md
@@ -7,7 +7,7 @@ description: New users will be automatically added to your organization if you h
 All new users who sign up with a [verified email domain](/docs/advanced/team-management/domain-verification) will be automatically added to your organization.
 Furthermore, you can also set which Organization roles / Product permissions they should get upon on-boarding.
 
-#### Steps to configure:
+## Steps to configure:
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 

--- a/website/docs/advanced/team-management/domain-verification.md
+++ b/website/docs/advanced/team-management/domain-verification.md
@@ -6,7 +6,7 @@ description: In order to use the SAML feature in ConfigCat, you need to verify y
 
 In order to use the [SAML Single Sign-On](/docs/advanced/team-management/saml/saml-overview) and the [Auto-assign Users](/docs/advanced/team-management/auto-assign-users) features, you have to verify the ownership of the domain that your company uses for email addresses.
 
-#### Steps to verify your domain:
+## Steps to verify your domain:
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 

--- a/website/docs/advanced/team-management/saml/identity-providers/adfs.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/adfs.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 Connect ConfigCat with Active Directory Federation Services (ADFS) via SAML.
 
-### Introduction
+## Introduction
 
 Each SSO Identity Provider requires specific information to configure a SAML integration. The following guide will walk you through on how you can connect ConfigCat with ADFS as a SAML Identity Provider.
 
-### 1. Collect SAML Metadata from ConfigCat
+## 1. Collect SAML Metadata from ConfigCat
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 
@@ -30,7 +30,7 @@ Each SSO Identity Provider requires specific information to configure a SAML int
 
     <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/dashboard/saml_config.png" alt="ConfigCat SAML configuration" />
 
-### 2. Configure a Relying Party Trust
+## 2. Configure a Relying Party Trust
 
 - Open the ADFS Management console, and click `Add Relying Party Trust`.
 
@@ -74,7 +74,7 @@ Then, click `Next`.
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/adfs/11_finish_party.png" alt="ADFS finish configuration" />
 
-### 3. Configure Claims Issuance Policy
+## 3. Configure Claims Issuance Policy
 
 - After adding the Relying Party Trust, the following dialog should appear.  
 Click `Add rule`.
@@ -98,7 +98,7 @@ Click `Add rule`.
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/adfs/15_finish_claims.png" alt="ADFS finish claims" />
 
-### 4. Configure ConfigCat with SAML Details from ADFS
+## 4. Configure ConfigCat with SAML Details from ADFS
 
 You can choose one of the following options to configure ConfigCat with SAML Identity Provider metadata.
 
@@ -164,7 +164,7 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
   </TabItem>
 </Tabs>
 
-### 5. Sign In
+## 5. Sign In
 
 - Go to the <a href="https://app.configcat.com/login" target="_blank">ConfigCat Log In</a> page, and click `COMPANY ACCOUNT - SAML`.
 
@@ -180,6 +180,6 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
 
 - You should be redirected to ConfigCat signed in with your company account.
 
-### 6. Next Steps
+## 6. Next Steps
 
 - Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/auth0.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/auth0.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 Connect ConfigCat with Auth0 via SAML.
 
-### Introduction
+## Introduction
 
 Each SSO Identity Provider requires specific information to configure a SAML integration. The following guide will walk you through on how you can connect ConfigCat with Auth0 as a SAML Identity Provider.
 
-### 1. Create an Application in Auth0
+## 1. Create an Application in Auth0
 
 - Log in to <a href="https://auth0.com/auth/login" target="_blank">Auth0</a>, select `Applications` from the menu, then click `Create Application`.
 
@@ -29,7 +29,7 @@ Each SSO Identity Provider requires specific information to configure a SAML int
 
 The next step will guide you on how to collect the information required for the appearing configuration dialog.
 
-### 2. Configure SAML for the Auth0 Application
+## 2. Configure SAML for the Auth0 Application
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 
@@ -59,7 +59,7 @@ The next step will guide you on how to collect the information required for the 
 
   - Click on `Save`.
 
-### 3. Configure ConfigCat with SAML Details from Auth0
+## 3. Configure ConfigCat with SAML Details from Auth0
 
 You can choose one of the following options to configure ConfigCat with SAML Identity Provider metadata.
 
@@ -93,7 +93,7 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
   </TabItem>
 </Tabs>
 
-### 4. Sign In
+## 4. Sign In
 
 - Go to the <a href="https://app.configcat.com/login" target="_blank">ConfigCat Log In</a> page, and click `COMPANY ACCOUNT - SAML`.
 
@@ -109,6 +109,6 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
 
 - You should be redirected to ConfigCat signed in with your company account.
 
-### 5. Next Steps
+## 5. Next Steps
 
 - Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/azure-ad.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/azure-ad.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 Connect ConfigCat with Azure Active Directory via SAML.
 
-### Introduction
+## Introduction
 
 Each SSO Identity Provider requires specific information to configure a SAML integration. The following guide will walk you through on how you can connect ConfigCat with Azure Active Directory as a SAML Identity Provider.
 
-### 1. Create an Azure AD Enterprise Application
+## 1. Create an Azure AD Enterprise Application
 
 - Log in to the <a href="https://portal.azure.com/" target="_blank">Azure Portal</a>, go to the `Azure Active Directory` resource, and select `Enterprise applications`.
 
@@ -37,7 +37,7 @@ Each SSO Identity Provider requires specific information to configure a SAML int
 
 The next step will guide you on how to collect the information required for Configuring SAML in the application.
 
-### 2. Configure SAML for the Azure Enterprise Application
+## 2. Configure SAML for the Azure Enterprise Application
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 
@@ -58,7 +58,7 @@ The next step will guide you on how to collect the information required for Conf
 
     <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/azure-ad/ad_urls.png" alt="Azure AD URLs" />
 
-### 3. Configure ConfigCat with SAML Details from Azure
+## 3. Configure ConfigCat with SAML Details from Azure
 
 You can choose one of the following options to configure ConfigCat with SAML Identity Provider metadata.
 
@@ -93,7 +93,7 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
   </TabItem>
 </Tabs>
 
-### 4. Assign Users to the Enterprise Application
+## 4. Assign Users to the Enterprise Application
 
 To let users authenticate via SAML, you need to assign individual users or groups to the Enterprise application.
 
@@ -105,7 +105,7 @@ To let users authenticate via SAML, you need to assign individual users or group
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/azure-ad/add_users.png" alt="Azure AD add user/group" />
 
-### 5. Sign In
+## 5. Sign In
 
 - Go to the <a href="https://app.configcat.com/login" target="_blank">ConfigCat Log In</a> page, and click `COMPANY ACCOUNT - SAML`.
 
@@ -121,6 +121,6 @@ To let users authenticate via SAML, you need to assign individual users or group
 
 - You should be redirected to ConfigCat signed in with your company account.
 
-### 6. Next Steps
+## 6. Next Steps
 
 - Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/google.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/google.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 Connect ConfigCat with Google via SAML.
 
-### Introduction
+## Introduction
 
 Each SSO Identity Provider requires specific information to configure a SAML integration. The following guide will walk you through on how you can connect ConfigCat with Google as a SAML Identity Provider.
 
-### 1. Create a SAML Application in Google
+## 1. Create a SAML Application in Google
 
 - Log in to <a href="https://admin.google.com/" target="_blank">Google Admin console</a>, select `Apps` from the side menu, then select `Web and mobile apps`.
 
@@ -29,7 +29,7 @@ Each SSO Identity Provider requires specific information to configure a SAML int
 
 The next step will guide you on how to configure ConfigCat with appearing information.
 
-### 2. Configure ConfigCat with SAML Details from Google
+## 2. Configure ConfigCat with SAML Details from Google
 
 - Copy the value of `SSO URL` and `Certificate` fields and save them for further use.
 
@@ -53,7 +53,7 @@ The next step will guide you on how to configure ConfigCat with appearing inform
 
 The next step will guide you on how to configure the Google App with details provided by ConfigCat.
 
-### 3. Configure the Google Application with Service Provider Details from ConfigCat
+## 3. Configure the Google Application with Service Provider Details from ConfigCat
 
 - Select `1. Set up your Identity Provider` step on the ConfigCat configuration dialog, and copy the following values to the Google App.
 
@@ -75,7 +75,7 @@ The next step will guide you on how to configure the Google App with details pro
 
 - Click `Save` on the ConfigCat SAML configuration dialog.
 
-### 4. Give Users Access to the Application
+## 4. Give Users Access to the Application
 
 - Click on `View details` under the `User access` section.
 
@@ -85,7 +85,7 @@ The next step will guide you on how to configure the Google App with details pro
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/google/on_for_everyone.png" alt="Google ON for everyone"/>
 
-### 5. Sign In
+## 5. Sign In
 
 - Go to the <a href="https://app.configcat.com/login" target="_blank">ConfigCat Log In</a> page, and click `COMPANY ACCOUNT - SAML`.
 
@@ -101,6 +101,6 @@ The next step will guide you on how to configure the Google App with details pro
 
 - You should be redirected to ConfigCat signed in with your company account.
 
-### 5. Next Steps
+## 5. Next Steps
 
 - Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/okta.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/okta.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 Connect ConfigCat with Okta via SAML.
 
-### Introduction
+## Introduction
 
 Each SSO Identity Provider requires specific information to configure a SAML integration. The following guide will walk you through on how you can connect ConfigCat with Okta as a SAML Identity Provider.
 
-### 1. Create an Application in Okta
+## 1. Create an Application in Okta
 
 - Log in to <a href="https://login.okta.com/" target="_blank">Okta</a>, go to the admin dashboard, and select `Applications`.
 
@@ -33,7 +33,7 @@ Each SSO Identity Provider requires specific information to configure a SAML int
 
 The next step will guide you on how to collect the information required for the appearing `Configure SAML` section.
 
-### 2. Configure SAML for the Okta Application
+## 2. Configure SAML for the Okta Application
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 
@@ -60,7 +60,7 @@ The next step will guide you on how to collect the information required for the 
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/okta/feedback.png" alt="Okta SAML feedback" />
 
-### 3. Configure ConfigCat with SAML Details from Okta
+## 3. Configure ConfigCat with SAML Details from Okta
 
 You can choose one of the following options to configure ConfigCat with SAML Identity Provider metadata.
 
@@ -102,7 +102,7 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
   </TabItem>
 </Tabs>
 
-### 4. Assign Users to Okta Application
+## 4. Assign Users to Okta Application
 
 To let users authenticate via SAML, you need to assign individual users or groups to the Okta application.
 
@@ -110,7 +110,7 @@ To let users authenticate via SAML, you need to assign individual users or group
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/okta/assign.png" alt="Okta assign to groups" />
 
-### 5. Sign In
+## 5. Sign In
 
 - Go to the <a href="https://app.configcat.com/login" target="_blank">ConfigCat Log In</a> page, and click `COMPANY ACCOUNT - SAML`.
 
@@ -126,6 +126,6 @@ To let users authenticate via SAML, you need to assign individual users or group
 
 - You should be redirected to ConfigCat signed in with your company account.
 
-### 6. Next Steps
+## 6. Next Steps
 
 - Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/saml/identity-providers/onelogin.md
+++ b/website/docs/advanced/team-management/saml/identity-providers/onelogin.md
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 
 Connect ConfigCat with OneLogin via SAML.
 
-### Introduction
+## Introduction
 
 Each SSO Identity Provider requires specific information to configure a SAML integration. The following guide will walk you through on how you can connect ConfigCat with OneLogin as a SAML Identity Provider.
 
-### 1. Create an Application in OneLogin
+## 1. Create an Application in OneLogin
 
 - Log in to <a href="https://app.onelogin.com/login" target="_blank">OneLogin</a>, and select `Applications`.
 
@@ -33,7 +33,7 @@ Each SSO Identity Provider requires specific information to configure a SAML int
 
 The next step will guide you on how to collect the information required for the appearing `Configuration` page.
 
-### 2. Configure SAML for the OneLogin Application
+## 2. Configure SAML for the OneLogin Application
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat dashboard</a>.
 
@@ -69,7 +69,7 @@ The next step will guide you on how to collect the information required for the 
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/onelogin/sso_signing_algo.png" alt="OneLogin SAML Signature Algorithm"  />
 
-### 3. Configure ConfigCat with SAML Details from OneLogin
+## 3. Configure ConfigCat with SAML Details from OneLogin
 
 You can choose one of the following options to configure ConfigCat with SAML Identity Provider metadata.
 
@@ -110,7 +110,7 @@ You can choose one of the following options to configure ConfigCat with SAML Ide
   </TabItem>
 </Tabs>
 
-### 4. Assign the OneLogin Application to Users
+## 4. Assign the OneLogin Application to Users
 
 To let users authenticate via SAML, you need to assign the newly created application to them.
 
@@ -134,7 +134,7 @@ To let users authenticate via SAML, you need to assign the newly created applica
 
   <img className="saml-tutorial-img zoomable" src="/docs/assets/saml/onelogin/app_details.png" alt="OneLogin application details"/>
 
-### 5. Sign In
+## 5. Sign In
 
 - Go to the <a href="https://app.configcat.com/login" target="_blank">ConfigCat Log In</a> page, and click `COMPANY ACCOUNT - SAML`.
 
@@ -150,6 +150,6 @@ To let users authenticate via SAML, you need to assign the newly created applica
 
 - You should be redirected to ConfigCat signed in with your company account.
 
-### 6. Next Steps
+## 6. Next Steps
 
 - Configure the [auto-assignment of users](/docs/advanced/team-management/auto-assign-users).

--- a/website/docs/advanced/team-management/single-sign-on-sso.md
+++ b/website/docs/advanced/team-management/single-sign-on-sso.md
@@ -20,7 +20,7 @@ Currently supported SSO providers:
 Under the `Login / Sign up methods` section you can enable / disable SSO providers one by one. These are organization level preferences. Your selection
 will be applied to all members of your organization.
 
-### SAML SSO
+## SAML SSO
 
 SAML SSO allows your team members to sign up and log in to ConfigCat via their company accounts using your own Identity Provider (IdP)
 Read more about [SAML SSO](/advanced/team-management/saml/saml-overview/).

--- a/website/docs/integrations/overview.md
+++ b/website/docs/integrations/overview.md
@@ -6,68 +6,68 @@ description: ConfigCat Integrations Overview. List of the available integrations
 
 Integrate ConfigCat with your technology stack and leverage all the benefits of Feature flags within your workflows.
 
-### Slack
+## Slack
 
 Get a Slack notification when a feature flag changes.
 [Documentation](integrations/slack.md)
 
-### Jira
+## Jira
 
 Turn features On / Off right from a linked Issue on your Jira board.
 [Documentation](integrations/jira.md)
 
-### Trello
+## Trello
 
 Turn features On / Off right from a linked Card on your Trello board.
 [Documentation](integrations/trello.md)
 
-### monday
+## monday
 
 Turn features On / Off right from a linked item on your monday board.
 [Documentation](integrations/monday.md)
 
-### DataDog
+## DataDog
 
 Ensure that every setting change in ConfigCat is sent to DataDog as an Event.
 [Documentation](integrations/datadog.md)
 
-### Zapier
+## Zapier
 
 Connect ConfigCat to 2,000+ other web services. Automated connections called Zaps, set up in minutes with no coding, can automate your day-to-day tasks and build workflows between apps that otherwise wouldn't be possible.
 [Documentation](integrations/zapier.md)
 
-### Zoho Flow
+## Zoho Flow
 
 Connect ConfigCat to 500+ other web apps without any code. It helps you automate day-to-day tasks and build complex business workflows within minutes.
 [Documentation](integrations/zoho-flow.md)
 
-### CircleCI
+## CircleCI
 
 Discover feature flag usages in your source code and upload the found code references to ConfigCat.
 [Documentation](integrations/circleci.md)
 
-### GitHub Actions
+## GitHub Actions
 
 Discover feature flag usages in your source code and upload the found code references to ConfigCat.
 [Documentation](integrations/github.md)
 
-### Bitbucket Pipe
+## Bitbucket Pipe
 
 Discover feature flag usages in your source code and upload the found code references to ConfigCat.
 [Documentation](integrations/bitbucket.md)
 
-### Bitrise Step
+## Bitrise Step
 
 Discover feature flag usages in your source code and upload the found code references to ConfigCat.
 [Documentation](integrations/bitrise.md)
 
-### Terraform
+## Terraform
 
 Manage feature flags directly from Terraform HCL scripts.
 
 [Documentation](integrations/terraform.md)
 
-### Amplitude
+## Amplitude
 
 Annotate your Amplitude charts with feature flag changes.
 [Documentation](integrations/amplitude.md)


### PR DESCRIPTION
### Description

Add missing H2s to the following `.md` files.
**Reason for change**: Reported in the weekly SE Ranking audit report

1. website/docs/integrations/overview.md
2. website/docs/advanced/team-management/domain-verification.md
3. website/docs/advanced/team-management/single-sign-on-sso.md
4. website/docs/advanced/team-management/auto-assign-users.md
5. website/docs/advanced/team-management/saml/identity-providers/azure-ad.md
6. website/docs/advanced/team-management/saml/identity-providers/adfs.md
7. website/docs/advanced/team-management/saml/identity-providers/google.md
8. website/docs/advanced/team-management/saml/identity-providers/okta.md
9. website/docs/advanced/team-management/saml/identity-providers/auth0.md
10. website/docs/advanced/team-management/saml/identity-providers/onelogin.md

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
