### PR TITLE
CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - working-directory: website
+        run: npm ci
+      - working-directory: website
+        run: npm run build


### PR DESCRIPTION
Just runs `npm run build` on PRs to make sure Docusorus can still build.

You might need to allow GitHub Actions to run from the repo settings.