### PR TITLE
Fix missing h2 tag issue

### DIFF
--- a/website/docs/service/status.md
+++ b/website/docs/service/status.md
@@ -5,7 +5,14 @@ title: Service Status & Monitoring
 
 To check the current health and status of the service visit: <a href="https://status.configcat.com" target="_blank">https://status.configcat.com</a>
 
-- **API:** Serves the Dashboard with data. Provides an interface for creating and updating Feature Flags. Runs the business logic and keeps CDN Servers consistent with the Database.
-- **CDN:** Serving our customers' JSON configuration files containing Feature Flags, Settings and their values. Designed to scale quickly and to handle a massive number of requests.
+## API
 
-- **Dashboard:** Graphical user interface (GUI) even for non-technical people to easily manage Configs, Feature Flags and Settings, invite team mates, add/remove Group Permissions or view the Audit Log.
+Serves the Dashboard with data. Provides an interface for creating and updating Feature Flags. Runs the business logic and keeps CDN Servers consistent with the Database.
+
+## CDN
+
+Serving our customers' JSON configuration files containing Feature Flags, Settings and their values. Designed to scale quickly and to handle a massive number of requests.
+
+## Dashboard
+
+Graphical user interface (GUI) even for non-technical people to easily manage Configs, Feature Flags and Settings, invite team mates, add/remove Group Permissions or view the Audit Log.


### PR DESCRIPTION
### Description

Fix the missing H2 tag issue.

#### Reason for change

This issue was found in last week's SE ranking report.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
