### PR TITLE
Add missing totalTime property

### DIFF
--- a/website/src/schema-markup/sdk-reference/ios.json
+++ b/website/src/schema-markup/sdk-reference/ios.json
@@ -4,6 +4,7 @@
   "name": "How to use feature flags in Swift iOS?",
   "description": "How to use feature flags in Swift iOS using ConfigCat Feature Flags",
   "image": "https://configcat.com/images/shared/home.png",
+  "totalTime": "PT10M",
   "estimatedCost": {
     "@type": "MonetaryAmount",
     "currency": "USD",


### PR DESCRIPTION
### Description

Add missing `totalTime `property to iOS SDK Schema Markup.

Ticket: <https://trello.com/c/gKFceB0K>

@sigewuzhere , This seems to only be missing for the iOS Schema Markup.

Snapshot of the issue this PR fixes:
![image](https://github.com/configcat/docs/assets/74829200/20897e42-fc10-4b19-843d-f4fe88ff8523)


### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
