### PR TITLE
SEO Fix: Update Title and Description for C# SDK Reference page

### DIFF
--- a/website/docs/sdk-reference/csharp.md
+++ b/website/docs/sdk-reference/csharp.md
@@ -1,7 +1,7 @@
 ---
 id: csharp
-title: .NET, .NET Core SDK Reference
-description: ConfigCat .NET, .NET Core SDK Reference. This is a step-by-step guide on how to use feature flags in your .NET, .NET Core application.
+title: C# SDK Reference
+description: ConfigCat C# SDK Reference. This is a step-by-step guide on how to use feature flags in your C# application.
 ---
 
 This page is outdated, please see the [ConfigCat .NET SDK Reference here](dotnet.md)

--- a/website/docs/sdk-reference/csharp.md
+++ b/website/docs/sdk-reference/csharp.md
@@ -1,7 +1,11 @@
 ---
 id: csharp
-title: C# SDK Reference
-description: ConfigCat C# SDK Reference. This is a step-by-step guide on how to use feature flags in your C# application.
+title: .NET, .NET Core SDK Reference
+description: ConfigCat .NET, .NET Core SDK Reference. This is a step-by-step guide on how to use feature flags in your .NET, .NET Core application.
 ---
+
+<head>
+    <link rel="canonical" href="https://configcat.com/docs/sdk-reference/dotnet/" />
+</head>
 
 This page is outdated, please see the [ConfigCat .NET SDK Reference here](dotnet.md)


### PR DESCRIPTION
### Description

This page was reported by our SE Ranking tool to have the same title and description as: https://configcat.com/docs/sdk-reference/dotnet/

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
