### PR TITLE
SEO Fix: Non-canonical pages in XML sitemap

### DIFF
--- a/website/docs/sdk-reference/csharp.md
+++ b/website/docs/sdk-reference/csharp.md
@@ -5,6 +5,7 @@ description: ConfigCat .NET, .NET Core SDK Reference. This is a step-by-step gui
 ---
 
 <head>
+    <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://configcat.com/docs/sdk-reference/dotnet/" />
 </head>
 


### PR DESCRIPTION
### Description

Fixed: Non-canonical pages in XML sitemap.

Reason for change:

Our weekly SE ranking report showed the following crawling issue:

- Non-canonical pages in XML sitemap - https://configcat.com/docs/sdk-reference/csharp/

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
