### PR TITLE
Add synchronous getValue docs to JS SDKs (part 2)

### DIFF
--- a/website/docs/sdk-reference/js-ssr.md
+++ b/website/docs/sdk-reference/js-ssr.md
@@ -575,6 +575,44 @@ settingValues = await configCatClient.getAllValueDetailsAsync(userObject);
 settingValues.forEach((details) => console.log(details));
 ```
 
+## Snapshots and synchronous feature flag evaluation
+
+On JavaScript platforms, the _ConfigCat_ client provides only asynchronous methods for evaluating feature flags and settings
+because these operations may involve network communication (downloading config data from the ConfigCat CDN servers),
+which is necessarily an asynchronous operation in JavaScript.
+
+However, there may be use cases where synchronous evaluation is preferable, thus, since v7.1.0, the JavaScript (SSR) SDK provides a way
+to synchronously evaluate feature flags and settings via *snapshots*.
+
+Using the `snapshot()` method, you can capture the current state of the _ConfigCat_ client (including the latest downloaded config data)
+and you can use the resulting snapshot object to synchronously evaluate feature flags and settings based on the captured state:
+
+```js
+const configCatClient = configcat.getClient("#YOUR-SDK-KEY#", configcat.PollingMode.ManualPoll);
+
+// Make sure that the latest config data is available locally.
+await configCatClient.forceRefreshAsync();
+
+const snapshot = configCatClient.snapshot();
+
+const user = new configcat.User('#UNIQUE-USER-IDENTIFIER#');
+for (const key of snapshot.getAllKeys()) {
+  const value = snapshot.getValue(key, null, user);
+  console.log(`${key}: ${value}`);
+}
+```
+
+In Auto Poll mode, you can use the `waitForReady` method to wait for that latest config data to become available locally:
+
+```js
+const configCatClient = configcat.getClient("#YOUR-SDK-KEY#", configcat.PollingMode.AutoPoll);
+
+// Make sure that the latest config data is available locally.
+await configCatClient.waitForReady();
+
+const snapshot = configCatClient.snapshot();
+```
+
 ## Using custom cache implementation
 
 The _ConfigCat SDK_ stores the downloaded config data in a local cache to minimize network traffic and enhance client performance.

--- a/website/docs/sdk-reference/node.md
+++ b/website/docs/sdk-reference/node.md
@@ -580,6 +580,44 @@ settingValues = await configCatClient.getAllValueDetailsAsync(userObject);
 settingValues.forEach((details) => console.log(details));
 ```
 
+## Snapshots and synchronous feature flag evaluation
+
+On JavaScript platforms, the _ConfigCat_ client provides only asynchronous methods for evaluating feature flags and settings
+because these operations may involve network communication (downloading config data from the ConfigCat CDN servers),
+which is necessarily an asynchronous operation in JavaScript.
+
+However, there may be use cases where synchronous evaluation is preferable, thus, since v10.1.0, the Node.js SDK provides a way
+to synchronously evaluate feature flags and settings via *snapshots*.
+
+Using the `snapshot()` method, you can capture the current state of the _ConfigCat_ client (including the latest downloaded config data)
+and you can use the resulting snapshot object to synchronously evaluate feature flags and settings based on the captured state:
+
+```js
+const configCatClient = configcat.getClient("#YOUR-SDK-KEY#", configcat.PollingMode.ManualPoll);
+
+// Make sure that the latest config data is available locally.
+await configCatClient.forceRefreshAsync();
+
+const snapshot = configCatClient.snapshot();
+
+const user = new configcat.User('#UNIQUE-USER-IDENTIFIER#');
+for (const key of snapshot.getAllKeys()) {
+  const value = snapshot.getValue(key, null, user);
+  console.log(`${key}: ${value}`);
+}
+```
+
+In Auto Poll mode, you can use the `waitForReady` method to wait for that latest config data to become available locally:
+
+```js
+const configCatClient = configcat.getClient("#YOUR-SDK-KEY#", configcat.PollingMode.AutoPoll);
+
+// Make sure that the latest config data is available locally.
+await configCatClient.waitForReady();
+
+const snapshot = configCatClient.snapshot();
+```
+
 ## Using ConfigCat behind a proxy
 
 Provide your own proxy server settings (proxy server/port) by adding a `proxy` option parameter when creating the ConfigCat client.


### PR DESCRIPTION
### Description

Add synchronous getValue docs to Node and JS SSR SDKs.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
