### PR TITLE
Fix function named argument in python.md

### DIFF
--- a/website/docs/sdk-reference/python.md
+++ b/website/docs/sdk-reference/python.md
@@ -409,8 +409,7 @@ The SDK can load your feature flag & setting overrides from a file.
 #### File
 
 ```python
-client = configcatclient.get(
-    sdk_key='#YOUR-SDK-KEY#',
+client = configcatclient.get('#YOUR-SDK-KEY#',
     ConfigCatOptions(
         flag_overrides=LocalFileFlagOverrides(
             file_path='path/to/the/local_flags.json',  # path to the file
@@ -690,8 +689,7 @@ dictionary = {
     'stringSetting': 'test'
 }
 
-client = configcatclient.get(
-    sdk_key='#YOUR-SDK-KEY#',
+client = configcatclient.get('#YOUR-SDK-KEY#',
     ConfigCatOptions(
         flag_overrides=LocalDictionaryFlagOverrides(source=dictionary, override_behaviour=OverrideBehaviour.LocalOnly)
     )


### PR DESCRIPTION
### Description

Fix function named argument in python.md

### Notes for QA

Changed the override samples. The samples should work now.

### Requirement checklist

- [ ] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
