### PR TITLE
Android SDK - Remove misleading logging dependency example.

### DIFF
--- a/website/docs/sdk-reference/android.mdx
+++ b/website/docs/sdk-reference/android.mdx
@@ -637,12 +637,6 @@ Call the `forceRefresh()` method on the client to download the latest config JSO
 
 As the SDK uses the facade of [slf4j](https://www.slf4j.org) for logging, so you can use any of the slf4j implementation packages.
 
-```
-dependencies {
-    implementation 'org.slf4j:slf4j-android:1.+'
-}
-```
-
 You can change the verbosity of the logs by passing a `LogLevel` parameter to the ConfigCatClientBuilder's `logLevel` function.
 
 ```java

--- a/website/versioned_docs/version-V1/sdk-reference/android.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/android.mdx
@@ -600,12 +600,6 @@ Call the `forceRefresh()` method on the client to download the latest config JSO
 
 As the SDK uses the facade of [slf4j](https://www.slf4j.org) for logging, so you can use any of the slf4j implementation packages.
 
-```
-dependencies {
-    implementation 'org.slf4j:slf4j-android:1.+'
-}
-```
-
 You can change the verbosity of the logs by passing a `LogLevel` parameter to the ConfigCatClientBuilder's `logLevel` function.
 
 ```java


### PR DESCRIPTION
### Description

Remove misleading logging dependency example from the Android SDK Logging section.
The example was misleading because not just the slf4j-android can be used as an slf4j implementation. Our sample apps use two different solutions as well.

### Trello card

[GitHub issue](https://github.com/configcat/android-sdk/issues/48)

### Notes for QA

From the Logging section a code example is removed. v1 and v2 modified as well.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
