### PR TITLE
Sub plan limits fix

### DIFF
--- a/website/docs/subscription-plan-limits.mdx
+++ b/website/docs/subscription-plan-limits.mdx
@@ -18,9 +18,9 @@ Every value marked with a \* in the table marks a technical limit. If you hit a 
 | Environments (per product)                     | 2       | 3       | 50\*    | 50\*       | 50\*      | 3       | 2       |
 | Segments (per product)                         | 2       | 3       | 500\*   | 1000\*     | 1000\*    | 3       | 3       |
 | Feature flags / Settings (per product)         | 10      | 100     | 500\*   | 500\*      | 500\*     | 1000    | 10      |
-| Percentage Options (per feature flag)                   | 4       | 8       | 500\*   | 500\*      | 500\*     | 8       | 4       |
+| Percentage Options (per feature flag)          | 4       | 8       | 500\*   | 500\*      | 500\*     | 8       | 4       |
 | Targeting Rules (per feature flag)             | 4       | 8       | 500\*   | 500\*      | 500\*     | 8       | 4       |
-| Targeting Rule comparison value length (chars) | 65535\* | 65535\* | 65535\* | 65535\*    | 65535\*   | 65535\* | 65535\* |
+| Targeting Rule comparison value length (chars) | 65535   | 65535   | 65535   | 65535      | 65535     | 65535   | 65535   |
 | Webhooks (per environment)                     | 1       | 3       | 200\*   | 200\*      | 200\*     | 3       | 1       |
 | Permission groups (per product)                | 1       | 2       | 100\*   | 100\*      | 100\*     | 2       | 3       |
 | Audit log retention (days)                     | 7       | 35      | 35      | 750        | 750       | 35      | 7       |

--- a/website/versioned_docs/version-V1/subscription-plan-limits.mdx
+++ b/website/versioned_docs/version-V1/subscription-plan-limits.mdx
@@ -18,9 +18,9 @@ Every value marked with a \* in the table marks a technical limit. If you hit a 
 | Environments (per product)                     | 2       | 3       | 50\*    | 50\*       | 50\*      | 3       | 2       |
 | Segments (per product)                         | 2       | 3       | 500\*   | 1000\*     | 1000\*    | 3       | 3       |
 | Feature flags / Settings (per product)         | 10      | 100     | 500\*   | 500\*      | 500\*     | 1000    | 10      |
-| Percentage Options (per feature flag)                   | 4       | 8       | 500\*   | 500\*      | 500\*     | 8       | 4       |
+| Percentage Options (per feature flag)          | 4       | 8       | 500\*   | 500\*      | 500\*     | 8       | 4       |
 | Targeting Rules (per feature flag)             | 4       | 8       | 500\*   | 500\*      | 500\*     | 8       | 4       |
-| Targeting Rule comparison value length (chars) | 65535\* | 65535\* | 65535\* | 65535\*    | 65535\*   | 65535\* | 65535\* |
+| Targeting Rule comparison value length (chars) | 65535   | 65535   | 65535   | 65535      | 65535     | 65535   | 65535   |
 | Webhooks (per environment)                     | 1       | 3       | 200\*   | 200\*      | 200\*     | 3       | 1       |
 | Permission groups (per product)                | 1       | 2       | 100\*   | 100\*      | 100\*     | 2       | 3       |
 | Audit log retention (days)                     | 7       | 35      | 35      | 750        | 750       | 35      | 7       |


### PR DESCRIPTION
### Description

We may occasionally increase the Targeting Rule comparison value length (chars) limit for an Organization, but I think it is not a good idea to advertise it as "If you hit a technical limit we will increase it for you". It could cause confusions.

### Notes for QA

I removed the asterisks from the  Targeting Rule comparison value length (chars) limit on the Subscription Plan Limits page.
### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
