### PR TITLE
Replace image zoom with a solution that don't transform images

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -26,7 +26,6 @@ const config: Config = {
       },
     ],
     'docusaurus-plugin-sass',
-    'docusaurus-plugin-image-zoom',
     [
       '@docusaurus/plugin-client-redirects',
       {
@@ -277,12 +276,8 @@ const config: Config = {
       searchParameters: {},
       externalUrlRegex: 'configcat\\.com/blog',
     },
-    zoom: {
+    imgZoom: {
       selector: '.markdown img:not([src^="http"])',
-      background: {
-        light: 'var(--ifm-background-color)',
-        dark: 'var(--ifm-background-color)'
-      },
     }
   } satisfies Preset.ThemeConfig,
   presets: [
@@ -322,6 +317,7 @@ const config: Config = {
   themes: ["docusaurus-theme-openapi-docs"],
   scripts: [],
   stylesheets: [],
+  clientModules: ['./src/client-modules/img-zoom'],
 };
 
 export default config;

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -278,6 +278,7 @@ const config: Config = {
     },
     imgZoom: {
       selector: '.markdown img:not([src^="http"])',
+      zoomedInClass: 'zoomed-in-img',
     }
   } satisfies Preset.ThemeConfig,
   presets: [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,7 +15,6 @@
         "@mdx-js/react": "^3.0.0",
         "@svgr/webpack": "^8.1.0",
         "clsx": "^2.1.0",
-        "docusaurus-plugin-image-zoom": "2.0.0",
         "docusaurus-plugin-openapi-docs": "3.0.0-beta.5",
         "docusaurus-plugin-sass": "^0.2.5",
         "docusaurus-theme-openapi-docs": "3.0.0-beta.5",
@@ -7323,18 +7322,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/docusaurus-plugin-image-zoom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-2.0.0.tgz",
-      "integrity": "sha512-TWHQZeoiged+95CESlZk++lihzl3pqw34n0/fbexx2AocmFhbo9K2scYDgYB8amki4/X6mUCLTPZE1pQvT+00Q==",
-      "dependencies": {
-        "medium-zoom": "^1.0.8",
-        "validate-peer-dependencies": "^2.2.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/theme-classic": ">=3.0.0"
-      }
-    },
     "node_modules/docusaurus-plugin-openapi-docs": {
       "version": "3.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/docusaurus-plugin-openapi-docs/-/docusaurus-plugin-openapi-docs-3.0.0-beta.5.tgz",
@@ -11267,11 +11254,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/medium-zoom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
-      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ=="
-    },
     "node_modules/memfs": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
@@ -13992,25 +13974,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-      "dependencies": {
-        "path-root-regex": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/path-scurry": {
       "version": "1.10.1",
@@ -16866,17 +16829,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-package-path": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
-      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
-      "dependencies": {
-        "path-root": "^0.1.1"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
@@ -19125,18 +19077,6 @@
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/validate-peer-dependencies": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz",
-      "integrity": "sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==",
-      "dependencies": {
-        "resolve-package-path": "^4.0.3",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/validate.io-array": {

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,6 @@
     "@mdx-js/react": "^3.0.0",
     "@svgr/webpack": "^8.1.0",
     "clsx": "^2.1.0",
-    "docusaurus-plugin-image-zoom": "2.0.0",
     "docusaurus-plugin-openapi-docs": "3.0.0-beta.5",
     "docusaurus-plugin-sass": "^0.2.5",
     "docusaurus-theme-openapi-docs": "3.0.0-beta.5",

--- a/website/src/client-modules/img-zoom/index.ts
+++ b/website/src/client-modules/img-zoom/index.ts
@@ -4,11 +4,12 @@ import './zoom.scss';
 
 const { themeConfig } = siteConfig;
 const { imgZoom }: { imgZoom?: ZoomOptions } = themeConfig;
-const { selector = '.markdown img', scrollOffset = 45 } = imgZoom || ({} as ZoomOptions);
+const { selector = '.markdown img', scrollOffset = 45, zoomedInClass = '' } = imgZoom || ({} as ZoomOptions);
 
 type ZoomOptions = {
   selector: string;
   scrollOffset: number;
+  zoomedInClass: string;
 }
 
 const zoom = () => {
@@ -104,13 +105,16 @@ const zoom = () => {
     overlay.classList.add('zoom-overlay');
     document.body.appendChild(overlay);
 
-    var targetImage = event.target;
-    var img = document.createElement('img')
-    img.onload = function () {
+    const targetImage = event.target;
+    const img = document.createElement('img');
+    img.onload = () => {
       document.body.classList.add('zoom-overlay-open');
       overlay.appendChild(img);
+    };
+    img.src = targetImage.currentSrc || targetImage.src;
+    if (zoomedInClass.length) {
+      img.classList.add(zoomedInClass);
     }
-    img.src = targetImage.currentSrc || targetImage.src
   }
 
   const _closeZoom = event => {
@@ -132,7 +136,7 @@ const zoom = () => {
   }
 
   const _getScrollTop = () => {
-    return window.scrollY || document.documentElement.scrollTop || document.body.scrollTop;
+    return window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
   }
 
   return { start, tearDown };

--- a/website/src/client-modules/img-zoom/index.ts
+++ b/website/src/client-modules/img-zoom/index.ts
@@ -1,0 +1,156 @@
+import siteConfig from '@generated/docusaurus.config';
+import type { ClientModule } from '@docusaurus/types';
+import './zoom.scss';
+
+const { themeConfig } = siteConfig;
+const { imgZoom }: { imgZoom?: ZoomOptions } = themeConfig;
+const { selector = '.markdown img', scrollOffset = 45 } = imgZoom || ({} as ZoomOptions);
+
+type ZoomOptions = {
+  selector: string;
+  scrollOffset: number;
+}
+
+const zoom = () => {
+  var zoomActive = false;
+  var busy = false;
+  var overlay = null;
+  var scrollPosition = 0;
+  var images = [];
+
+  const start = () => {
+    document.body.addEventListener('click', _clickHandler);
+    document.addEventListener('keyup', _keyUpHandler);
+    document.addEventListener('scroll', _scrollHandler);
+    window.addEventListener('resize', _resizeHandler);
+
+    images = Array.from(document.querySelectorAll(selector)).filter(e => e.tagName === 'IMG');
+    _attachToImages(images);
+  };
+
+  const tearDown = () => {
+    document.body.removeEventListener('click', _clickHandler);
+    document.removeEventListener('keyup', _keyUpHandler);
+    document.removeEventListener('scroll', _scrollHandler);
+    window.removeEventListener('resize', _resizeHandler);
+    _detachFromImages(images);
+
+    images = [];
+    zoomActive = false;
+    busy = false;
+    scrollPosition = 0;
+  }
+
+  const _clickHandler = event => {
+    if (busy) {
+      return;
+    }
+    if (zoomActive) {
+      _closeZoom(event);
+      return;
+    }
+    const { target } = event
+    if (images.indexOf(target) === -1) {
+      return
+    }
+    _zoom(event);
+  }
+
+  const _scrollHandler = () => {
+    if (!zoomActive) {
+      return;
+    }
+    const delta = scrollPosition - _getScrollTop();
+    if (Math.abs(delta) > scrollOffset) {
+      _closeActiveZoom();
+    }
+  }
+
+  const _keyUpHandler = event => {
+    if (!zoomActive) {
+      return;
+    }
+    const key = event.key || event.keyCode
+    if (key === 'Escape' || key === 'Esc' || key === 27) {
+      _closeActiveZoom();
+    }
+  }
+
+  const _resizeHandler = () => {
+    if (!zoomActive) {
+      return;
+    }
+    _closeActiveZoom();
+  }
+
+  const _attachToImages = (images: Element[]) => {
+    images.forEach(img => {
+      img.classList.add('zoom-img');
+    });
+  }
+
+  const _detachFromImages = (images: Element[]) => {
+    images.forEach(img => {
+      img.classList.remove('zoom-img');
+    });
+  }
+
+  const _zoom = event => {
+    event.stopPropagation();
+    zoomActive = true;
+    scrollPosition = _getScrollTop();
+
+    overlay = document.createElement('div');
+    overlay.classList.add('zoom-overlay');
+    document.body.appendChild(overlay);
+
+    var targetImage = event.target;
+    var img = document.createElement('img')
+    img.onload = function () {
+      document.body.classList.add('zoom-overlay-open');
+      overlay.appendChild(img);
+    }
+    img.src = targetImage.currentSrc || targetImage.src
+  }
+
+  const _closeZoom = event => {
+    event.stopPropagation();
+    _closeActiveZoom();
+  }
+
+  const _closeActiveZoom = () => {
+    busy = true;
+    document.body.addEventListener('transitionend', _closed);
+    document.body.classList.remove('zoom-overlay-open');
+  }
+
+  const _closed = () => {
+    document.body.removeEventListener('transitionend', _closed);
+    document.body.removeChild(overlay);
+    busy = false;
+    zoomActive = false;
+  }
+
+  const _getScrollTop = () => {
+    return window.scrollY || document.documentElement.scrollTop || document.body.scrollTop;
+  }
+
+  return { start, tearDown };
+};
+
+const zoomModule = zoom();
+
+const module: ClientModule = {
+  onRouteUpdate({ location, previousLocation }) {
+    if (location.pathname !== previousLocation?.pathname) {
+      return () => zoomModule.tearDown();
+    }
+    return undefined;
+  },
+  onRouteDidUpdate({ location, previousLocation }) {
+    if (location.pathname !== previousLocation?.pathname) {
+      zoomModule.start();
+    }
+  },
+};
+export default module;

--- a/website/src/client-modules/img-zoom/zoom.scss
+++ b/website/src/client-modules/img-zoom/zoom.scss
@@ -1,0 +1,23 @@
+.zoom-overlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: zoom-out;
+    z-index: 9999;
+    background: var(--ifm-background-color);
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    transition: opacity 300ms;
+  }
+  
+  .zoom-overlay-open .zoom-overlay {
+    opacity: 1;
+  }
+
+  .zoom-img {
+    cursor: zoom-in;
+  }

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -55,6 +55,10 @@
   margin-bottom: 1rem;
 }
 
+.zoomed-in-img {
+  border: 1px solid rgb(224, 224, 224);
+}
+
 table td:first-child {
   white-space: nowrap;
 }

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -51,6 +51,7 @@
 }
 
 .saml-tutorial-img {
+  border: 1px solid rgb(224, 224, 224);
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
### Description

This PR replaces the image zoom functionality with a solution that doesn't transform images, so texts on them won't be blurry upon zooming in.

Before:
![image](https://github.com/configcat/docs/assets/13772020/3b4fa5b4-12fa-427c-b3eb-0cfd3851a5bb)

After:
![image](https://github.com/configcat/docs/assets/13772020/f52685b2-b4d5-4f07-9978-a428cc930086)

### Notes for QA

- Check zoomable images.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
