### PR TITLE
Fix zoomed image position / browser back bug

### DIFF
--- a/website/src/client-modules/img-zoom/index.ts
+++ b/website/src/client-modules/img-zoom/index.ts
@@ -13,11 +13,11 @@ type ZoomOptions = {
 }
 
 const zoom = () => {
-  var zoomActive = false;
-  var busy = false;
-  var overlay = null;
-  var scrollPosition = 0;
-  var images = [];
+  let zoomActive = false;
+  let busy = false;
+  let overlay = null;
+  let scrollPosition = 0;
+  let images = [];
 
   const start = () => {
     document.body.addEventListener('click', _clickHandler);
@@ -30,6 +30,9 @@ const zoom = () => {
   };
 
   const tearDown = () => {
+    if (zoomActive) {
+      _closeActiveZoom();
+    }
     document.body.removeEventListener('click', _clickHandler);
     document.removeEventListener('keyup', _keyUpHandler);
     document.removeEventListener('scroll', _scrollHandler);
@@ -107,6 +110,7 @@ const zoom = () => {
 
     const targetImage = event.target;
     const img = document.createElement('img');
+    img.classList.add('zoom-img-zoomed-in');
     img.onload = () => {
       document.body.classList.add('zoom-overlay-open');
       overlay.appendChild(img);

--- a/website/src/client-modules/img-zoom/zoom.scss
+++ b/website/src/client-modules/img-zoom/zoom.scss
@@ -18,6 +18,12 @@
     opacity: 1;
   }
 
+  .zoom-img-zoomed-in {
+    width: auto;
+    height: auto;
+    max-height: 100%;
+  }
+
   .zoom-img {
     cursor: zoom-in;
   }


### PR DESCRIPTION
### Description

This PR fixes: 

1. Wrong positioning of the zoomed-in image when the holding container is too narrow.
  Before:
  ![image](https://github.com/configcat/docs/assets/13772020/f4d66b74-2356-4445-9c59-813f629cabfe)
  After:
  ![image](https://github.com/configcat/docs/assets/13772020/28e15094-4a0f-47a8-a681-a319f1f13900)

2. Pressing the browser's back button didn't close the zoomed-in image correctly.

### Notes for QA

Play with image zoom in different page sizes & back button.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
