### PR TITLE
Remove ':' character from titles

### DIFF
--- a/website/docs/advanced/notifications-webhooks.mdx
+++ b/website/docs/advanced/notifications-webhooks.mdx
@@ -244,6 +244,7 @@ echo hash_equals($calculated_signature, $received_signature); // must be true
 
 ```go
 package main
+
 import (
   "fmt"
   "crypto/hmac"

--- a/website/docs/advanced/team-management/auto-assign-users.mdx
+++ b/website/docs/advanced/team-management/auto-assign-users.mdx
@@ -7,7 +7,7 @@ description: New users will be automatically added to your organization if you h
 All new users who sign up with a [verified email domain](domain-verification.mdx) will be automatically added to your organization.
 Furthermore, you can also set which Organization roles / Product permissions they should get upon on-boarding.
 
-## Steps to configure:
+## Steps to configure
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat Dashboard</a>.
 

--- a/website/docs/advanced/team-management/domain-verification.mdx
+++ b/website/docs/advanced/team-management/domain-verification.mdx
@@ -6,7 +6,7 @@ description: In order to use the SAML feature in ConfigCat, you need to verify y
 
 In order to use the [SAML Single Sign-On](../../advanced/team-management/saml/overview.mdx) and the [Auto-assign Users](auto-assign-users.mdx) features, you have to verify the ownership of the domain that your company uses for email addresses.
 
-## Steps to verify your domain:
+## Steps to verify your domain
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat Dashboard</a>.
 

--- a/website/docs/integrations/zapier.mdx
+++ b/website/docs/integrations/zapier.mdx
@@ -46,11 +46,11 @@ Available fields to include in your flow:
 
 ## Example Slack notification setup
 
-### Configuration in Zapier:
+### Configuration in Zapier
 
 <img src="/docs/assets/zapier_config.png" className="zoomable" alt="zapier_config" />
 
-### Result in Slack:
+### Result in Slack
 
 <img src="/docs/assets/zapier_slack.png" className="zoomable" alt="zapier_slack" />
 

--- a/website/docs/main-concepts.mdx
+++ b/website/docs/main-concepts.mdx
@@ -19,7 +19,7 @@ A _Feature Flag_ is a _Setting_ of type Bool.
 | Type       | Type of information you'd like to keep in the _Setting_. e.g., On/Off Toggle, Text, Number                             |
 | Value      | The actual value of your _Setting_. e.g., `true`, `false`. Can be different in each environment.                       |
 
-### About _Setting_ types:
+### About _Setting_ types
 
 | Setting Kind   | Setting Type | Description                                                                       |
 | -------------- | ------------ | --------------------------------------------------------------------------------- |

--- a/website/docs/news.mdx
+++ b/website/docs/news.mdx
@@ -22,12 +22,12 @@ and a host of new features designed to streamline your feature flag and configur
 - Advanced targeting rules with AND conditions for more precise user targeting.
 - New comparators and prerequisite flags for complex rule creation.
 
-### Gradual Release & Opt-in:
+### Gradual Release & Opt-in
 
 Config V2 will be rolled out gradually over the next three months. Interested customers are encouraged to 
 opt-in early by <a href="https://configcat.com/support/">contacting our support team</a>
 
-### Seamless Migration, No Immediate Changes Required:
+### Seamless Migration, No Immediate Changes Required
 Post-release, rest assured that your existing configurations will continue to function just as before.
 There's no immediate pressure to migrate, allowing you to transition to Config V2 when it suits you best.
 

--- a/website/docs/sdk-reference/android.mdx
+++ b/website/docs/sdk-reference/android.mdx
@@ -29,7 +29,7 @@ The minimum supported Android SDK version is 21 (Lollipop).
 
 When you use R8 or ProGuard, the aar artifact automatically applies the [included rules](https://github.com/configcat/android-sdk/blob/master/configcat-proguard-rules.pro) for the SDK.
 
-## Getting Started:
+## Getting Started
 
 ### 1. Add the ConfigCat SDK to your project
 
@@ -39,7 +39,7 @@ dependencies {
 }
 ```
 
-### 2. Import the ConfigCat SDK:
+### 2. Import the ConfigCat SDK
 
 ```java
 import com.configcat.*;

--- a/website/docs/sdk-reference/cpp.mdx
+++ b/website/docs/sdk-reference/cpp.mdx
@@ -17,7 +17,7 @@ export const CPPSchema = require('@site/src/schema-markup/sdk-reference/cpp.json
 
 <a href="https://github.com/configcat/cpp-sdk" target="_blank">ConfigCat C++ SDK on GitHub</a>
 
-## Getting Started:
+## Getting Started
 
 ### 1. Add the ConfigCat SDK to your project
 
@@ -49,7 +49,7 @@ With **[Vcpkg](https://github.com/microsoft/vcpkg)**
   ./vcpkg/vcpkg install configcat
   ```
 
-### 2. Include _configcat.h_ header in your application code:
+### 2. Include _configcat.h_ header in your application code
 
 ```cpp
 #include <configcat/configcat.h>

--- a/website/docs/sdk-reference/elixir.mdx
+++ b/website/docs/sdk-reference/elixir.mdx
@@ -380,7 +380,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code:
+# Calling code
 FirstFlags.get_value("someKey", "default value")
 SecondFlags.get_value("otherKey", "other default")
 ```
@@ -407,7 +407,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code:
+# Calling code
 ConfigCat.get_value("someKey", "default value", client: :first)
 ConfigCat.get_value("otherKey", "other default", client: :second)
 ```

--- a/website/docs/sdk-reference/elixir.mdx
+++ b/website/docs/sdk-reference/elixir.mdx
@@ -380,7 +380,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code
+# Calling code:
 FirstFlags.get_value("someKey", "default value")
 SecondFlags.get_value("otherKey", "other default")
 ```
@@ -407,7 +407,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code
+# Calling code:
 ConfigCat.get_value("someKey", "default value", client: :first)
 ConfigCat.get_value("otherKey", "other default", client: :second)
 ```

--- a/website/docs/sdk-reference/go.mdx
+++ b/website/docs/sdk-reference/go.mdx
@@ -22,7 +22,7 @@ export const GoSchema = require('@site/src/schema-markup/sdk-reference/go.json')
 
 <a href="https://github.com/configcat/go-sdk" target="_blank">ConfigCat Go SDK on GitHub</a>
 
-## Getting Started:
+## Getting Started
 
 ### 1. Get the SDK with `go`
 

--- a/website/docs/sdk-reference/ios.mdx
+++ b/website/docs/sdk-reference/ios.mdx
@@ -64,7 +64,7 @@ dependencies: [
 </TabItem>
 </Tabs>
 
-### 2. Import the ConfigCat SDK:
+### 2. Import the ConfigCat SDK
 
 <Tabs groupId="ios-languages">
 <TabItem value="swift" label="Swift">

--- a/website/docs/sdk-reference/js-ssr.mdx
+++ b/website/docs/sdk-reference/js-ssr.mdx
@@ -33,7 +33,7 @@ npm i configcat-js-ssr
 import * as configcat from 'configcat-js-ssr';
 ```
 
-### 2. Create the _ConfigCat_ client with your SDK Key:
+### 2. Create the _ConfigCat_ client with your SDK Key
 
 ```js
 const configCatClient = configcat.getClient('#YOUR-SDK-KEY#');

--- a/website/docs/sdk-reference/js.mdx
+++ b/website/docs/sdk-reference/js.mdx
@@ -51,7 +51,7 @@ import * as configcat from 'configcat-js';
 </TabItem>
 </Tabs>
 
-### 2. Create the _ConfigCat_ client with your SDK Key:
+### 2. Create the _ConfigCat_ client with your SDK Key
 
 ```js
 const configCatClient = configcat.getClient('#YOUR-SDK-KEY#');

--- a/website/docs/sdk-reference/unreal.mdx
+++ b/website/docs/sdk-reference/unreal.mdx
@@ -18,7 +18,7 @@ export const CPPSchema = require('@site/src/schema-markup/sdk-reference/cpp.json
 
 <a href="https://github.com/configcat/unreal-engine-sdk" target="_blank">ConfigCat Unreal SDK on GitHub</a>
 
-## Getting Started:
+## Getting Started
 
 ### 1. Installing the ConfigCat plugin to your project
 

--- a/website/versioned_docs/version-V1/advanced/notifications-webhooks.mdx
+++ b/website/versioned_docs/version-V1/advanced/notifications-webhooks.mdx
@@ -243,6 +243,7 @@ echo hash_equals($calculated_signature, $received_signature); // must be true
 
 ```go
 package main
+
 import (
   "fmt"
   "crypto/hmac"

--- a/website/versioned_docs/version-V1/advanced/team-management/auto-assign-users.mdx
+++ b/website/versioned_docs/version-V1/advanced/team-management/auto-assign-users.mdx
@@ -7,7 +7,7 @@ description: New users will be automatically added to your organization if you h
 All new users who sign up with a [verified email domain](domain-verification.mdx) will be automatically added to your organization.
 Furthermore, you can also set which Organization roles / Product permissions they should get upon on-boarding.
 
-## Steps to configure:
+## Steps to configure
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat Dashboard</a>.
 

--- a/website/versioned_docs/version-V1/advanced/team-management/domain-verification.mdx
+++ b/website/versioned_docs/version-V1/advanced/team-management/domain-verification.mdx
@@ -6,7 +6,7 @@ description: In order to use the SAML feature in ConfigCat, you need to verify y
 
 In order to use the [SAML Single Sign-On](../../advanced/team-management/saml/overview.mdx) and the [Auto-assign Users](auto-assign-users.mdx) features, you have to verify the ownership of the domain that your company uses for email addresses.
 
-## Steps to verify your domain:
+## Steps to verify your domain
 
 - Open your organization's authentication settings on the <a href="https://app.configcat.com/organization/authentication" target="_blank">ConfigCat Dashboard</a>.
 

--- a/website/versioned_docs/version-V1/integrations/zapier.mdx
+++ b/website/versioned_docs/version-V1/integrations/zapier.mdx
@@ -46,11 +46,11 @@ Available fields to include in your flow:
 
 ## Example Slack notification setup
 
-### Configuration in Zapier:
+### Configuration in Zapier
 
 <img src="/docs/assets/zapier_config.png" className="zoomable" alt="zapier_config" />
 
-### Result in Slack:
+### Result in Slack
 
 <img src="/docs/assets/zapier_slack.png" className="zoomable" alt="zapier_slack" />
 

--- a/website/versioned_docs/version-V1/main-concepts.mdx
+++ b/website/versioned_docs/version-V1/main-concepts.mdx
@@ -19,7 +19,7 @@ A _Feature Flag_ is a _Setting_ of type Bool.
 | Type       | Type of information you'd like to keep in the _Setting_. e.g., On/Off Toggle, Text, Number                             |
 | Value      | The actual value of your _Setting_. e.g., `true`, `false`. Can be different in each environment.                       |
 
-### About _Setting_ types:
+### About _Setting_ types
 
 | Setting Kind   | Setting Type | Description                                                                       |
 | -------------- | ------------ | --------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-V1/news.mdx
+++ b/website/versioned_docs/version-V1/news.mdx
@@ -22,12 +22,12 @@ and a host of new features designed to streamline your feature flag and configur
 - Advanced targeting rules with AND conditions for more precise user targeting.
 - New comparators and prerequisite flags for complex rule creation.
 
-### Gradual Release & Opt-in:
+### Gradual Release & Opt-in
 
 Config V2 will be rolled out gradually over the next three months. Interested customers are encouraged to 
 opt-in early by <a href="https://configcat.com/support/">contacting our support team</a>
 
-### Seamless Migration, No Immediate Changes Required:
+### Seamless Migration, No Immediate Changes Required
 Post-release, rest assured that your existing configurations will continue to function just as before.
 There's no immediate pressure to migrate, allowing you to transition to Config V2 when it suits you best.
 
@@ -138,7 +138,7 @@ All ConfigCat SDKs released before Feb, 2020 will stop working after October 1st
 
 Although we aim to keep older SDK versions functional, those trailing more than one major or minor release lack official support and SLA. Many of these outdated SDKs will no longer remain functional.
 
-### Affected SDKs and versions:
+### Affected SDKs and versions
 
 | SDK Type | Latest available version | Will stop working |
 | -------- | ------------------------ | ----------------- |

--- a/website/versioned_docs/version-V1/sdk-reference/android.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/android.mdx
@@ -35,7 +35,7 @@ The minimum supported Android SDK version is 21 (Lollipop).
 
 When you use R8 or ProGuard, the aar artifact automatically applies the [included rules](https://github.com/configcat/android-sdk/blob/master/configcat-proguard-rules.pro) for the SDK.
 
-## Getting Started:
+## Getting Started
 
 ### 1. Add the ConfigCat SDK to your project
 
@@ -45,7 +45,7 @@ dependencies {
 }
 ```
 
-### 2. Import the ConfigCat SDK:
+### 2. Import the ConfigCat SDK
 
 ```java
 import com.configcat.*;

--- a/website/versioned_docs/version-V1/sdk-reference/cpp.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/cpp.mdx
@@ -23,7 +23,7 @@ export const CPPSchema = require('@site/src/schema-markup/sdk-reference/cpp.json
 This documentation applies to the **v3.x version** of the ConfigCat C++ SDK. For the documentation of the latest release, please refer to [this page](../../../docs/sdk-reference/cpp.mdx).
 :::
 
-## Getting Started:
+## Getting Started
 
 ### 1. Add the ConfigCat SDK to your project
 
@@ -55,7 +55,7 @@ With **[Vcpkg](https://github.com/microsoft/vcpkg)**
   ./vcpkg/vcpkg install configcat
   ```
 
-### 2. Include _configcat.h_ header in your application code:
+### 2. Include _configcat.h_ header in your application code
 
 ```cpp
 #include <configcat/configcat.h>

--- a/website/versioned_docs/version-V1/sdk-reference/elixir.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/elixir.mdx
@@ -345,7 +345,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code:
+# Calling code
 FirstFlags.get_value("someKey", "default value")
 SecondFlags.get_value("otherKey", "other default")
 ```
@@ -372,7 +372,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code:
+# Calling code
 ConfigCat.get_value("someKey", "default value", client: :first)
 ConfigCat.get_value("otherKey", "other default", client: :second)
 ```

--- a/website/versioned_docs/version-V1/sdk-reference/elixir.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/elixir.mdx
@@ -345,7 +345,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code
+# Calling code:
 FirstFlags.get_value("someKey", "default value")
 SecondFlags.get_value("otherKey", "other default")
 ```
@@ -372,7 +372,7 @@ def start(_type, _args) do
   Supervisor.start_link(children, opts)
 end
 
-# Calling code
+# Calling code:
 ConfigCat.get_value("someKey", "default value", client: :first)
 ConfigCat.get_value("otherKey", "other default", client: :second)
 ```

--- a/website/versioned_docs/version-V1/sdk-reference/go.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/go.mdx
@@ -25,7 +25,7 @@ export const GoSchema = require('@site/src/schema-markup/sdk-reference/go.json')
 This documentation applies to the **v8.x version** of the ConfigCat Go SDK. For the documentation of the latest release, please refer to [this page](../../../docs/sdk-reference/go.mdx).
 :::
 
-## Getting Started:
+## Getting Started
 
 ### 1. Get the SDK with `go`
 

--- a/website/versioned_docs/version-V1/sdk-reference/ios.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/ios.mdx
@@ -70,7 +70,7 @@ dependencies: [
 </TabItem>
 </Tabs>
 
-### 2. Import the ConfigCat SDK:
+### 2. Import the ConfigCat SDK
 
 <Tabs groupId="ios-languages">
 <TabItem value="swift" label="Swift">

--- a/website/versioned_docs/version-V1/sdk-reference/js-ssr.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/js-ssr.mdx
@@ -39,7 +39,7 @@ npm i configcat-js-ssr
 import * as configcat from 'configcat-js-ssr';
 ```
 
-### 2. Create the _ConfigCat_ client with your SDK Key:
+### 2. Create the _ConfigCat_ client with your SDK Key
 
 ```js
 const configCatClient = configcat.getClient('#YOUR-SDK-KEY#');

--- a/website/versioned_docs/version-V1/sdk-reference/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/js.mdx
@@ -57,7 +57,7 @@ import * as configcat from 'configcat-js';
 </TabItem>
 </Tabs>
 
-### 2. Create the _ConfigCat_ client with your SDK Key:
+### 2. Create the _ConfigCat_ client with your SDK Key
 
 ```js
 const configCatClient = configcat.getClient('#YOUR-SDK-KEY#');

--- a/website/versioned_docs/version-V1/sdk-reference/unreal.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/unreal.mdx
@@ -24,7 +24,7 @@ export const CPPSchema = require('@site/src/schema-markup/sdk-reference/cpp.json
 This documentation applies to the **v1.x version** of the ConfigCat Unreal SDK. For the documentation of the latest release, please refer to [this page](../../../docs/sdk-reference/unreal.mdx).
 :::
 
-## Getting Started:
+## Getting Started
 
 ### 1. Installing the ConfigCat plugin to your project
 


### PR DESCRIPTION
### Description

Removed `:` character from docs titles.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
