### PR TITLE
Webhook changed by

### DIFF
--- a/website/docs/advanced/notifications-webhooks.mdx
+++ b/website/docs/advanced/notifications-webhooks.mdx
@@ -29,6 +29,7 @@ ConfigCat will replace the following variables in the request body:
 | **##EnvironmentId##**      | ID of the Environment.                                                                            |
 | **##URL##**                | A direct link to the Config in the _ConfigCat Dashboard._                                         |
 | **##ChangeNotes##**        | The **Mandatory notes** added to the actual changeset.                                            |
+| **##ChangedBy##**          | The name and email address of the user who made the changes.                                      |
 | **##ChangeDetails##**      | Details of the change in JSON format including setting name, old, new values and Targeting Rules. |
 | **##ChangeDetailsTeams##** | Details of the change in MS Teams format.                                                         |
 | **##ChangeDetailsSlack##** | Details of the change in Slack message format.                                                    |

--- a/website/versioned_docs/version-V1/advanced/notifications-webhooks.mdx
+++ b/website/versioned_docs/version-V1/advanced/notifications-webhooks.mdx
@@ -29,8 +29,10 @@ ConfigCat will replace the following variables in the request body:
 | **##EnvironmentId##**      | ID of the Environment.                                                                            |
 | **##URL##**                | A direct link to the Config in the _ConfigCat Dashboard._                                         |
 | **##ChangeNotes##**        | The **Mandatory notes** added to the actual changeset.                                            |
+| **##ChangedBy##**          | The name and email address of the user who made the changes.                                      |
 | **##ChangeDetails##**      | Details of the change in JSON format including setting name, old, new values and Targeting Rules. |
 | **##ChangeDetailsTeams##** | Details of the change in MS Teams format.                                                         |
+| **##ChangeDetailsSlack##** | Details of the change in Slack message format.                                                    |
 
 The structure of the JSON array injected into the **##ChangeDetails##** looks like the following:
 


### PR DESCRIPTION
### Description

Webhooks now can specify ##ChangedBy## in the content and it will be replaced by the user's email and name who made the changes.

### Trello card

https://trello.com/c/1rTjg9QS/228-who-changed-a-flag-webhook-variable

### Requirement checklist

- [ ] I have validated my changes on a test/local environment.
- [ ] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
