### PR TITLE
Add Rust SDK to the overview page

### DIFF
--- a/website/docs/sdk-reference/overview.mdx
+++ b/website/docs/sdk-reference/overview.mdx
@@ -102,6 +102,11 @@ Check out our language specific<a href="https://app.configcat.com/sdkkey" target
 - [Documentation](./ruby.mdx) on how to connect your application.
 - <a href="https://github.com/configcat/ruby-sdk" target="_blank">GitHub repository of the ConfigCat Ruby SDK.</a>
 
+## Rust
+
+- [Documentation](./rust.mdx) on how to connect your application.
+- <a href="https://github.com/configcat/rust-sdk" target="_blank">GitHub repository of the ConfigCat Rust SDK.</a>
+
 ## Swift (iOS)
 
 - [Documentation](./ios.mdx) on how to connect your application.

--- a/website/versioned_docs/version-V1/sdk-reference/overview.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/overview.mdx
@@ -102,6 +102,11 @@ Check out our language specific<a href="https://app.configcat.com/sdkkey" target
 - [Documentation](./ruby.mdx) on how to connect your application.
 - <a href="https://github.com/configcat/ruby-sdk" target="_blank">GitHub repository of the ConfigCat Ruby SDK.</a>
 
+## Rust
+
+- [Documentation](./rust.mdx) on how to connect your application.
+- <a href="https://github.com/configcat/rust-sdk" target="_blank">GitHub repository of the ConfigCat Rust SDK.</a>
+
 ## Swift (iOS)
 
 - [Documentation](./ios.mdx) on how to connect your application.


### PR DESCRIPTION
### Description

Add Rust SDK to the overview page.

### Trello card

- n/a

### Notes for QA

- n/a

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
