### PR TITLE
Fix broken URL link in amplitude integration documentation

### DIFF
--- a/website/docs/integrations/amplitude.mdx
+++ b/website/docs/integrations/amplitude.mdx
@@ -46,7 +46,7 @@ Every annotation sent to Amplitude by ConfigCat has:
 
 ## Sending feature flag evaluation analytics to Amplitude Experiments {#experiments}
 
-Ensures that feature flag evaluations are logged into <a href="https://www.docs.developers.amplitude.com/experiment/" target="_blank" rel="noopener noreferrer">Amplitude Experiments</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
+Ensures that feature flag evaluations are logged into <a href="https://amplitude.com/docs/experiment/" target="_blank" rel="noopener noreferrer">Amplitude Experiments</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
 
 ### Setup
 

--- a/website/versioned_docs/version-V1/integrations/amplitude.mdx
+++ b/website/versioned_docs/version-V1/integrations/amplitude.mdx
@@ -46,7 +46,7 @@ Every annotation sent to Amplitude by ConfigCat has:
 
 ## Sending feature flag evaluation analytics to Amplitude Experiments {#experiments}
 
-Ensures that feature flag evaluations are logged into <a href="https://www.docs.developers.amplitude.com/experiment/" target="_blank" rel="noopener noreferrer">Amplitude Experiments</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
+Ensures that feature flag evaluations are logged into <a href="https://amplitude.com/docs/experiment/" target="_blank" rel="noopener noreferrer">Amplitude Experiments</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
 
 ### Setup
 


### PR DESCRIPTION
### Description

Replaced broken link: https://www.docs.developers.amplitude.com/experiment/ with https://amplitude.com/docs/experiment

### Trello card

n/a

### Notes for QA

What part of the application were affected by the changes?

`/website/docs/integrations/amplitude.mdx` 

What should be tested?

Check if the updated link is ok

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
