### PR TITLE
Add docs of additional usage patterns

### DIFF
--- a/website/docs/advanced/code-references/bitbucket-pipe.mdx
+++ b/website/docs/advanced/code-references/bitbucket-pipe.mdx
@@ -27,6 +27,7 @@ You can find more information about Bitbucket Pipelines <a target="_blank" href=
        #   flag_key_to_exclue_1
        #   flag_key_to_exclue_2
        # ALIAS_PATTERNS: (\w+) = :CC_KEY,const (\w+) = feature_flags\.enabled\(:CC_KEY\)  # optional
+       # USAGE_PATTERNS: feature_flags\.enabled\(:CC_KEY\)
        # VERBOSE: 'true'         # optional
    ```
 
@@ -44,4 +45,5 @@ Scan reports are uploaded for each branch of your repository that triggers the j
 | `SUB_FOLDER`         | Sub-folder to scan, relative to the repository root folder.               |          |                     |
 | `EXCLUDE_KEYS`       | List of feature flag keys that must be excluded from the scan report.     |          |                     |
 | `ALIAS_PATTERNS`     | Comma delimited list of custom regex patterns used to search for additional aliases. |   |                 |
+| `USAGE_PATTERNS`     | Comma delimited list of custom regex patterns that describe additional feature flag key usages. |   |      |
 | `VERBOSE`            | Turns on detailed logging.                                                |          | false               |

--- a/website/docs/advanced/code-references/circleci-orb.mdx
+++ b/website/docs/advanced/code-references/circleci-orb.mdx
@@ -36,6 +36,7 @@ You can find more information about CircleCI Orbs <a target="_blank" href="https
              #   flag_key_to_exclue_1
              #   flag_key_to_exclue_2
              # alias-patterns: (\w+) = :CC_KEY,const (\w+) = feature_flags\.enabled\(:CC_KEY\) # optional
+             # usage-patterns: feature_flags\.enabled\(:CC_KEY\)   # optional
              # verbose: true           # optional
    ```
 
@@ -58,4 +59,5 @@ Scan reports are uploaded for each branch of your repository that triggers the w
 | `sub-folder`          | Sub-folder to scan, relative to the repository root folder.                                                                                                                                            |          |                     |
 | `exclude-keys`        | List of feature flag keys that must be excluded from the scan report.                                                                                                                                  |          |                     |
 | `alias-patterns`      | Comma delimited list of custom regex patterns used to search for additional aliases.                                                                                                                   |          |                     |
+| `usage-patterns`      | Comma delimited list of custom regex patterns that describe additional feature flag key usages. |  |          |
 | `verbose`             | Turns on detailed logging.                                                                                                                                                                             |          | false               |

--- a/website/docs/advanced/code-references/github-action.mdx
+++ b/website/docs/advanced/code-references/github-action.mdx
@@ -38,6 +38,7 @@ You can find more information about GitHub Actions <a target="_blank" href="http
              #   flag_key_to_exclue_1
              #   flag_key_to_exclue_2
              # alias-patterns: (\w+) = :CC_KEY,const (\w+) = feature_flags\.enabled\(:CC_KEY\) #optional
+             # usage-patterns: feature_flags\.enabled\(:CC_KEY\)   # optional, comma delimited flag key usage patterns
              # verbose: true             # optional
    ```
 
@@ -58,4 +59,5 @@ Scan reports are uploaded for each branch of your repository that triggers the w
 | `sub-folder`   | Sub-folder to scan, relative to the repository root folder.                                                                                       |          |                     |
 | `exclude-keys` | List of feature flag keys that must be excluded from the scan report.                                                                             |          |                     |
 | `alias-patterns` | Comma delimited list of custom regex patterns used to search for additional aliases.                                                            |          |                     |
+| `usage-patterns` | Comma delimited list of custom regex patterns that describe additional feature flag key usages. |  |                     |
 | `verbose`      | Turns on detailed logging.                                                                                                                        |          | false               |

--- a/website/docs/advanced/code-references/overview.mdx
+++ b/website/docs/advanced/code-references/overview.mdx
@@ -58,6 +58,36 @@ To get the ID of a Config, follow the steps below:
 
 The scanner looks for feature flag and setting keys between quotation marks (`'` `"` `` ` ``) in the first place.
 
+:::info
+There's an option to extend the feature flag and setting key usage regex patterns with the `--usage-patterns` argument of the `scan` command. 
+
+```bash
+configcat scan <dir> --usage-patterns "<pattern1>" "<pattern2>"
+```
+
+Usage patterns can also be set via the `CONFIGCAT_USAGE_PATTERNS` environment variable as a comma delimited list.
+
+```bash
+export CONFIGCAT_USAGE_PATTERNS="<pattern1>,<pattern2>";
+```
+
+The regex pattern must include the `CC_KEY` placeholder that represents the actual feature flag or setting key in your code.
+For example, the following pattern allows the recognition of Ruby symbols as flag key usage:
+
+```bash
+configcat scan <dir> --usage-patterns ":CC_KEY"
+```
+
+It will match for the following usage:
+
+```ruby
+if FeatureFlags.enabled(:my_feature_key)
+  #...
+end
+```
+
+:::
+
 ### Aliases
 
 The found keys' context is examined for **aliases**, like variables, constants, or enumerations used to store these keys.

--- a/website/versioned_docs/version-V1/advanced/code-references/bitbucket-pipe.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/bitbucket-pipe.mdx
@@ -27,6 +27,7 @@ You can find more information about Bitbucket Pipelines <a target="_blank" href=
        #   flag_key_to_exclue_1
        #   flag_key_to_exclue_2
        # ALIAS_PATTERNS: (\w+) = :CC_KEY,const (\w+) = feature_flags\.enabled\(:CC_KEY\)  # optional
+       # USAGE_PATTERNS: feature_flags\.enabled\(:CC_KEY\)
        # VERBOSE: 'true'         # optional
    ```
 
@@ -44,4 +45,5 @@ Scan reports are uploaded for each branch of your repository that triggers the j
 | `SUB_FOLDER`         | Sub-folder to scan, relative to the repository root folder.               |          |                     |
 | `EXCLUDE_KEYS`       | List of feature flag keys that must be excluded from the scan report.     |          |                     |
 | `ALIAS_PATTERNS`     | Comma delimited list of custom regex patterns used to search for additional aliases. |   |                 |
+| `USAGE_PATTERNS`     | Comma delimited list of custom regex patterns that describe additional feature flag key usages. |   |      |
 | `VERBOSE`            | Turns on detailed logging.                                                |          | false               |

--- a/website/versioned_docs/version-V1/advanced/code-references/circleci-orb.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/circleci-orb.mdx
@@ -36,6 +36,7 @@ You can find more information about CircleCI Orbs <a target="_blank" href="https
              #   flag_key_to_exclue_1
              #   flag_key_to_exclue_2
              # alias-patterns: (\w+) = :CC_KEY,const (\w+) = feature_flags\.enabled\(:CC_KEY\) # optional
+             # usage-patterns: feature_flags\.enabled\(:CC_KEY\)   # optional
              # verbose: true           # optional
    ```
 
@@ -58,4 +59,5 @@ Scan reports are uploaded for each branch of your repository that triggers the w
 | `sub-folder`          | Sub-folder to scan, relative to the repository root folder.                                                                                                                                            |          |                     |
 | `exclude-keys`        | List of feature flag keys that must be excluded from the scan report.                                                                                                                                  |          |                     |
 | `alias-patterns`      | Comma delimited list of custom regex patterns used to search for additional aliases.                                                                                                                   |          |                     |
+| `usage-patterns`      | Comma delimited list of custom regex patterns that describe additional feature flag key usages. |  |          |
 | `verbose`             | Turns on detailed logging.                                                                                                                                                                             |          | false               |

--- a/website/versioned_docs/version-V1/advanced/code-references/github-action.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/github-action.mdx
@@ -38,6 +38,7 @@ You can find more information about GitHub Actions <a target="_blank" href="http
              #   flag_key_to_exclue_1
              #   flag_key_to_exclue_2
              # alias-patterns: (\w+) = :CC_KEY,const (\w+) = feature_flags\.enabled\(:CC_KEY\) #optional
+             # usage-patterns: feature_flags\.enabled\(:CC_KEY\)   # optional, comma delimited flag key usage patterns
              # verbose: true             # optional
    ```
 
@@ -58,4 +59,5 @@ Scan reports are uploaded for each branch of your repository that triggers the w
 | `sub-folder`   | Sub-folder to scan, relative to the repository root folder.                                                                                       |          |                     |
 | `exclude-keys` | List of feature flag keys that must be excluded from the scan report.                                                                             |          |                     |
 | `alias-patterns` | Comma delimited list of custom regex patterns used to search for additional aliases.                                                            |          |                     |
+| `usage-patterns` | Comma delimited list of custom regex patterns that describe additional feature flag key usages. |  |                     |
 | `verbose`      | Turns on detailed logging.                                                                                                                        |          | false               |

--- a/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
@@ -58,6 +58,35 @@ To get the ID of a Config, follow the steps below:
 
 The scanner looks for feature flag and setting keys between quotation marks (`'` `"` `` ` ``) in the first place.
 
+:::info
+There's an option to extend the feature flag and setting key usage regex patterns with the `--usage-patterns` argument of the `scan` command. 
+
+```bash
+configcat scan <dir> --usage-patterns "<pattern1>" "<pattern2>"
+```
+
+Usage patterns can also be set via the `CONFIGCAT_USAGE_PATTERNS` environment variable as a comma delimited list.
+
+```bash
+export CONFIGCAT_USAGE_PATTERNS="<pattern1>,<pattern2>";
+```
+
+The regex pattern must include the `CC_KEY` placeholder that represents the actual feature flag or setting key in your code.
+For example, the following pattern allows the recognition of Ruby symbols as flag key usage:
+
+```bash
+configcat scan <dir> --usage-patterns ":CC_KEY"
+```
+
+It will match for the following usage:
+
+```ruby
+if FeatureFlags.enabled(:my_feature_key)
+  #...
+end
+```
+:::
+
 ### Aliases
 
 The found keys' context is examined for **aliases**, like variables, constants, or enumerations used to store these keys.


### PR DESCRIPTION
### Description

Added docs for the new `--usage-patterns` argument of the `scan` CLI command.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
