### PR TITLE
Add OpenFeature providers to SDK reference

### DIFF
--- a/website/docs/sdk-reference/android.mdx
+++ b/website/docs/sdk-reference/android.mdx
@@ -259,8 +259,8 @@ User user = User.newBuilder().build("john@example.com");
 
 ```java
 java.util.Map<String,Object> customAttributes = new java.util.HashMap<String,Object>();
-    customAttributes.put("SubscriptionType", "Pro");
-    customAttributes.put("UserRole", "Admin");
+customAttributes.put("SubscriptionType", "Pro");
+customAttributes.put("UserRole", "Admin");
 
 User user = User.newBuilder()
     .email("john@example.com")
@@ -273,9 +273,9 @@ The `Custom` dictionary also allows attribute values other than `String` values:
 
 ```java
 java.util.Map<String,Object> customAttributes = new java.util.HashMap<String,Object>();
-    customAttributes.put("Rating", 4.5);
-    customAttributes.put("RegisteredAt", new Date("2023-11-22 12:34:56 +00:00"));
-    customAttributes.put("Roles", new String[]{"Role1", "Role2"});
+customAttributes.put("Rating", 4.5);
+customAttributes.put("RegisteredAt", new Date("2023-11-22 12:34:56 +00:00"));
+customAttributes.put("Roles", new String[]{"Role1", "Role2"});
 
 User user = User.newBuilder()
     .email("john@example.com")
@@ -543,7 +543,7 @@ List<EvaluationDetails<?>> allValueDetails = client.getAllValueDetails(user);
 ```java
 User user = User.newBuilder().build("#UNIQUE-USER-IDENTIFIER#");
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#");
-        client.getAllValueDetailsAsync(user).thenAccept(allValueDetails -> { });
+client.getAllValueDetailsAsync(user).thenAccept(allValueDetails -> { });
 ```
 
 ## Cache

--- a/website/docs/sdk-reference/go.mdx
+++ b/website/docs/sdk-reference/go.mdx
@@ -114,7 +114,7 @@ If you want to use multiple SDK Keys in the same application, create only one _C
 
 ## Anatomy of `Get[TYPE]Value()`
 
-Basically all of the value evaluator methods share the same signature, they only differ in their served value type. `GetBoolValue()` is for evaluating feature flags, `GetIntValue()` and `GetFloatValue()` are for numeric and `GetStringValue()` is for textual settings.
+All feature flag evaluator methods share the same signature, they only differ in their served value type. `GetBoolValue()` is for evaluating feature flags, `GetIntValue()` and `GetFloatValue()` are for numeric and `GetStringValue()` is for textual settings.
 
 | Parameters     | Description                                                                                        |
 | -------------- | -------------------------------------------------------------------------------------------------- |

--- a/website/docs/sdk-reference/java.mdx
+++ b/website/docs/sdk-reference/java.mdx
@@ -265,8 +265,8 @@ User user = User.newBuilder().build("john@example.com");
 
 ```java
 java.util.Map<String,Object> customAttributes = new java.util.HashMap<String,Object>();
-    customAttributes.put("SubscriptionType", "Pro");
-    customAttributes.put("UserRole", "Admin");
+customAttributes.put("SubscriptionType", "Pro");
+customAttributes.put("UserRole", "Admin");
 
 User user = User.newBuilder()
     .email("john@example.com")
@@ -279,9 +279,9 @@ The `Custom` dictionary also allows attribute values other than `String` values:
 
 ```java
 java.util.Map<String,Object> customAttributes = new java.util.HashMap<String,Object>();
-    customAttributes.put("Rating", 4.5);
-    customAttributes.put("RegisteredAt", new Date("2023-11-22 12:34:56 +00:00"));
-    customAttributes.put("Roles", new String[]{"Role1", "Role2"});
+customAttributes.put("Rating", 4.5);
+customAttributes.put("RegisteredAt", new Date("2023-11-22 12:34:56 +00:00"));
+customAttributes.put("Roles", new String[]{"Role1", "Role2"});
 
 User user = User.newBuilder()
     .email("john@example.com")
@@ -395,7 +395,7 @@ Use the `cacheRefreshIntervalInSeconds` option parameter of the `PollingModes.la
 
 ```java
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options -> {
-        options.pollingMode(PollingModes.lazyLoad(60 /* the cache will expire in 120 seconds */));
+    options.pollingMode(PollingModes.lazyLoad(60 /* the cache will expire in 120 seconds */));
 });
 ```
 
@@ -413,7 +413,7 @@ Manual polling gives you full control over when the `config JSON` (with the sett
 
 ```java
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options ->{
-        options.pollingMode(PollingModes.manualPoll());
+    options.pollingMode(PollingModes.manualPoll());
 });
 
 client.forceRefresh();
@@ -699,7 +699,7 @@ map.put("doubleSetting", 3.14);
 map.put("stringSetting", "test");
 
 ConfigCatClient client = ConfigCatClient.get("localhost", options -> {
-        options.flagOverrides(OverrideDataSourceBuilder.map(map), OverrideBehaviour.LOCAL_ONLY)
+    options.flagOverrides(OverrideDataSourceBuilder.map(map), OverrideBehaviour.LOCAL_ONLY)
 });
 ```
 

--- a/website/docs/sdk-reference/js.mdx
+++ b/website/docs/sdk-reference/js.mdx
@@ -49,8 +49,8 @@ import * as configcat from 'configcat-js';
 ```html
 <script
   type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/configcat-js@latest/dist/configcat.min.js"
-></script>
+  src="https://cdn.jsdelivr.net/npm/configcat-js@latest/dist/configcat.min.js">
+</script>
 ```
 
 </TabItem>

--- a/website/docs/sdk-reference/openfeature/dotnet.mdx
+++ b/website/docs/sdk-reference/openfeature/dotnet.mdx
@@ -1,0 +1,108 @@
+---
+id: dotnet
+title: OpenFeature Provider for .NET
+description: ConfigCat OpenFeature Provider for .NET. This is a step-by-step guide on how to use ConfigCat with the OpenFeature .NET SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.ConfigCat" target="_blank">ConfigCat OpenFeature Provider for .NET on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+<Tabs groupId="dotnet-install">
+<TabItem value="Powershell / NuGet Package Manager Console" label="Powershell / NuGet Package Manager Console">
+
+```powershell
+Install-Package OpenFeature.Contrib.Providers.ConfigCat
+```
+
+</TabItem>
+<TabItem value=".NET CLI" label=".NET CLI">
+
+```bash
+dotnet add package OpenFeature.Contrib.Providers.ConfigCat
+```
+
+</TabItem>
+<TabItem value="Package Reference" label="Package Reference">
+
+```xml
+<PackageReference Include="OpenFeature.Contrib.Providers.ConfigCat" />
+```
+
+</TabItem>
+</Tabs>
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes the SDK key and an optional `ConfigCatClientOptions` argument containing the additional configuration options for the [ConfigCat .NET SDK](../../dotnet/#creating-the-configcat-client):
+
+```cs
+using OpenFeature.Contrib.Providers.ConfigCat;
+
+// Build options for the ConfigCat SDK.
+var options = new ConfigCatClientOptions
+{
+    PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(60));
+    Logger = new ConsoleLogger(LogLevel.Warning);
+    // ...
+};
+
+// Configure the provider.
+OpenFeature.Api.Instance.SetProvider(new ConfigCatProvider("#YOUR-SDK-KEY#", options));
+
+// Create a client.
+var client = OpenFeature.Api.Instance.GetClient();
+```
+
+For more information about all the configuration options, see the [.NET SDK documentation](../../dotnet/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```cs
+var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false);
+if(isAwesomeFeatureEnabled)
+{
+    doTheNewThing();
+}
+else
+{
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../dotnet/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `Id`/`Identifier`  | `Identifier` | &#9745;  | 
+| `Email`            | `Email`      |          | 
+| `Country`          | `Country`    |          | 
+| Any other          | `Custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```cs
+var context = new EvaluationContext()
+    .Set("Id", "#SOME-USER-ID#")
+    .Set("Email", "configcat@example.com")
+    .Set("Country", "CountryID")
+    .Set("Rating", 4.5)
+    .Set("RegisteredAt", DateTime.Parse("2023-11-22 12:34:56 +00:00", CultureInfo.InvariantCulture))
+    .Build();
+
+var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.ConfigCat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://www.nuget.org/packages/OpenFeature.Contrib.Providers.ConfigCat" target="_blank">ConfigCat OpenFeature Provider on nuget.org</a>

--- a/website/docs/sdk-reference/openfeature/go.mdx
+++ b/website/docs/sdk-reference/openfeature/go.mdx
@@ -43,7 +43,7 @@ For more information about all the configuration options, see the [Go SDK docume
 
 ### 3. Evaluate your feature flag
 
-```rust
+```go
 isAwesomeFeatureEnabled, err := client.BooleanValue(
     context.Background(), "isAwesomeFeatureEnabled", false, openfeature.EvaluationContext{},
 )

--- a/website/docs/sdk-reference/openfeature/go.mdx
+++ b/website/docs/sdk-reference/openfeature/go.mdx
@@ -1,0 +1,91 @@
+---
+id: go
+title: OpenFeature Provider for Go
+description: ConfigCat OpenFeature Provider for Go. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Go SDK.
+---
+
+<a href="https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider for Go on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+```bash
+go get github.com/open-feature/go-sdk-contrib/providers/configcat
+```
+
+### 2. Initialize the provider
+
+The ConfigCat Provider needs a pre-configured [ConfigCat Go SDK](../../go/#creating-the-configcat-client) client:
+
+```go
+import (
+    "context"
+
+    sdk "github.com/configcat/go-sdk/v9"
+    configcat "github.com/open-feature/go-sdk-contrib/providers/configcat/pkg"
+    "github.com/open-feature/go-sdk/openfeature"
+)
+
+// Configure the ConfigCat SDK.
+configcatClient := sdk.NewCustomClient(sdk.Config{SDKKey: "#YOUR-SDK-KEY#",
+    PollingMode: sdk.AutoPoll,
+    PollInterval: time.Second * 60})
+
+// Configure the provider.
+openfeature.SetProvider(configcat.NewProvider(configcatClient))
+
+# Create a client.
+client := openfeature.NewClient("app")
+```
+
+For more information about all the configuration options, see the [Go SDK documentation](../../go/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```rust
+isAwesomeFeatureEnabled, err := client.BooleanValue(
+    context.Background(), "isAwesomeFeatureEnabled", false, openfeature.EvaluationContext{},
+)
+
+if err == nil && isAwesomeFeatureEnabled {
+    doTheNewThing()
+} else {
+    doTheOldThing()
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../go/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context              | User Object  | Required |
+| ------------------------------- | ------------ | -------- |
+| `openfeature.TargetingKey`      | `Identifier` | &#9745;  | 
+| `configcat.EmailKey`            | `Email`      |          | 
+| `configcat.CountryKey`          | `Country`    |          | 
+| Any other                       | `Custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```go
+registeredAt, _ := time.Parse(time.DateTime, "2023-11-22 12:34:56")
+context := openfeature.NewEvaluationContext("#SOME-USER-ID#", map[string]any{
+    configcat.EmailKey: "configcat@example.com",
+    configcat.CountryKey: "CountryID",
+    "Rating": 4.5,
+    "RegisteredAt": registeredAt,
+    "Roles": []string{"Role1","Role2"},
+})
+
+isAwesomeFeatureEnabled, err := client.BooleanValue(
+    context.Background(), "isAwesomeFeatureEnabled", false, context,
+)
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>

--- a/website/docs/sdk-reference/openfeature/java.mdx
+++ b/website/docs/sdk-reference/openfeature/java.mdx
@@ -58,7 +58,7 @@ For more information about all the configuration options, see the [Java SDK docu
 
 ### 3. Evaluate your feature flag
 
-```cs
+```java
 boolean isAwesomeFeatureEnabled = client.getBooleanValue("isAwesomeFeatureEnabled", false);
 if(isAwesomeFeatureEnabled)
 {
@@ -86,7 +86,7 @@ The following table shows how the different context attributes are mapped to Use
 
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
-```cs
+```java
 MutableContext evaluationContext = new MutableContext();
 evaluationContext.setTargetingKey("#SOME-USER-ID#");
 evaluationContext.add("Email", "configcat@example.com");

--- a/website/docs/sdk-reference/openfeature/java.mdx
+++ b/website/docs/sdk-reference/openfeature/java.mdx
@@ -1,0 +1,102 @@
+---
+id: java
+title: OpenFeature Provider for Java
+description: ConfigCat OpenFeature Provider for Java. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Java SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/java-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider for Java on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+<Tabs groupId="java-install">
+<TabItem value="Gradle" label="Gradle">
+
+```groovy title="build.gradle"
+dependencies {
+    implementation 'dev.openfeature.contrib.providers:configcat:0.0.4'
+}
+```
+
+</TabItem>
+<TabItem value="Maven" label="Maven">
+
+```xml title="pom.xml"
+<dependency>
+  <groupId>dev.openfeature.contrib.providers</groupId>
+  <artifactId>configcat</artifactId>
+  <version>0.0.4</version>
+</dependency>
+```
+
+</TabItem>
+</Tabs>
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes a `ConfigCatProviderConfig` argument containing the configuration options for the [ConfigCat Java SDK](../../java/#creating-the-configcat-client):
+
+```java
+// Build options for the ConfigCat SDK.
+ConfigCatProviderConfig configCatProviderConfig = ConfigCatProviderConfig.builder()
+    .sdkKey("#YOUR-SDK-KEY#")
+    .pollingMode(PollingModes.autoPoll())
+    .logLevel(LogLevel.WARNING)
+    .build();
+
+// Configure the provider.
+OpenFeatureAPI.getInstance().setProviderAndWait(new ConfigCatProvider(configCatProviderConfig));
+
+// Create a client.
+Client client = OpenFeatureAPI.getInstance().getClient();
+```
+
+For more information about all the configuration options, see the [Java SDK documentation](../../java/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```cs
+boolean isAwesomeFeatureEnabled = client.getBooleanValue("isAwesomeFeatureEnabled", false);
+if(isAwesomeFeatureEnabled)
+{
+    doTheNewThing();
+}
+else
+{
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../java/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `TargetingKey`     | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```cs
+MutableContext evaluationContext = new MutableContext();
+evaluationContext.setTargetingKey("#SOME-USER-ID#");
+evaluationContext.add("Email", "configcat@example.com");
+evaluationContext.add("Country", "CountryID");
+evaluationContext.add("Rating", 4.5);
+
+boolean isAwesomeFeatureEnabled = client.getBooleanValue("isAwesomeFeatureEnabled", false, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/java-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://search.maven.org/artifact/dev.openfeature.contrib.providers/configcat" target="_blank">ConfigCat OpenFeature Provider on Maven Central</a>

--- a/website/docs/sdk-reference/openfeature/js.mdx
+++ b/website/docs/sdk-reference/openfeature/js.mdx
@@ -1,0 +1,97 @@
+---
+id: js
+title: OpenFeature Provider for JavaScript
+description: ConfigCat OpenFeature Provider for JavaScript. This is a step-by-step guide on how to use ConfigCat with the OpenFeature JavaScript SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat-web" target="_blank">ConfigCat OpenFeature Provider for JavaScript on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+<Tabs groupId="js-install">
+<TabItem value="NPM" label="NPM">
+
+```bash
+npm i @openfeature/config-cat-web-provider
+```
+
+</TabItem>
+<TabItem value="CDN" label="CDN">
+
+```html
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js"
+></script>
+```
+
+</TabItem>
+</Tabs>
+### 2. Initialize the provider
+
+The `ConfigCatWebProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat JavaScript SDK](../../js/#creating-the-configcat-client):
+
+```js
+import { ConfigCatWebProvider } from '@openfeature/config-cat-web-provider';
+
+// Build options for the ConfigCat SDK.
+const options = { 
+    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+    // ...
+}
+
+// Configure the provider.
+OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', options));
+ 
+// Create a client.
+const client = OpenFeature.getClient();
+```
+
+For more information about all the configuration options, see the [JavaScript SDK documentation](../../js/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```js
+const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);
+if(isAwesomeFeatureEnabled) {
+    doTheNewThing();
+} else {
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../js/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targetingKey`     | `identifier` | &#9745;  | 
+| `email`            | `email`      |          | 
+| `country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```js
+await OpenFeature.setContext({ 
+    targetingKey: '#SOME-USER-ID#', 
+    email: 'configcat@example.com', 
+    country: 'CountryID',
+});
+
+const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat-web" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://www.npmjs.com/package/@openfeature/config-cat-web-provider" target="_blank">ConfigCat OpenFeature Provider in NPM</a>

--- a/website/docs/sdk-reference/openfeature/js.mdx
+++ b/website/docs/sdk-reference/openfeature/js.mdx
@@ -26,8 +26,8 @@ npm i @openfeature/config-cat-web-provider
 ```html
 <script
   type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js"
-></script>
+  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js">
+</script>
 ```
 
 </TabItem>

--- a/website/docs/sdk-reference/openfeature/node.mdx
+++ b/website/docs/sdk-reference/openfeature/node.mdx
@@ -1,0 +1,82 @@
+---
+id: node
+title: OpenFeature Provider for Node.js
+description: ConfigCat OpenFeature Provider for Node. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Node.js SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat" target="_blank">ConfigCat OpenFeature Provider for Node.js on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+```bash
+npm i @openfeature/config-cat-provider
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat Node.js SDK](../../node/#creating-the-configcat-client):
+
+```js
+import { ConfigCatProvider } from '@openfeature/config-cat-provider';
+
+// Build options for the ConfigCat SDK.
+const options = { 
+    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+    // ...
+}
+
+// Configure the provider.
+OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', PollingMode.AutoPoll, options));
+ 
+// Create a client.
+const client = OpenFeature.getClient();
+```
+
+For more information about all the configuration options, see the [Node.js SDK documentation](../../node/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```js
+const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false);
+if(isAwesomeFeatureEnabled) {
+    doTheNewThing();
+} else {
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../node/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targetingKey`     | `identifier` | &#9745;  | 
+| `email`            | `email`      |          | 
+| `country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```js
+const context = { 
+    targetingKey: '#SOME-USER-ID#', 
+    email: 'configcat@example.com', 
+    country: 'CountryID',
+};
+
+const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://www.npmjs.com/package/@openfeature/config-cat-provider" target="_blank">ConfigCat OpenFeature Provider in NPM</a>

--- a/website/docs/sdk-reference/openfeature/overview.mdx
+++ b/website/docs/sdk-reference/openfeature/overview.mdx
@@ -1,0 +1,20 @@
+---
+id: overview
+title: OpenFeature Providers
+description: List of all supported OpenFeature Providers.
+---
+
+OpenFeature is an open specification that provides a vendor-agnostic, community-driven API for feature flagging. 
+
+OpenFeature providers are the abstraction between an OpenFeature SDK and an underlying flag management system like ConfigCat. To learn more, see the [OpenFeature documentation](https://openfeature.dev/docs/reference/intro).
+
+ConfigCat offers providers for the following platforms supported by OpenFeature SDKs:
+
+- [.NET](./dotnet.mdx)
+- [Go](./go.mdx)
+- [Java](./java.mdx)
+- [JavaScript](./js.mdx)
+- [Node](./node.mdx)
+- [PHP](./php.mdx)
+- [Python](./python.mdx)
+- [Rust](./rust.mdx)

--- a/website/docs/sdk-reference/openfeature/php.mdx
+++ b/website/docs/sdk-reference/openfeature/php.mdx
@@ -1,0 +1,98 @@
+---
+id: php
+title: OpenFeature Provider for PHP
+description: ConfigCat OpenFeature Provider for PHP. This is a step-by-step guide on how to use ConfigCat with the OpenFeature PHP SDK.
+---
+
+[![Build Status](https://github.com/configcat/openfeature-php/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/configcat/openfeature-php/actions/workflows/ci.yml)
+[![Latest Stable Version](https://poser.pugx.org/configcat/openfeature-provider/version)](https://packagist.org/packages/configcat/openfeature-provider)
+[![Total Downloads](https://poser.pugx.org/configcat/openfeature-provider/downloads)](https://packagist.org/packages/configcat/openfeature-provider)
+
+<a href="https://github.com/configcat/openfeature-php" target="_blank">ConfigCat OpenFeature Provider for PHP on GitHub</a>
+
+## Requirements
+- PHP >= 8.1
+
+## Getting started
+
+### 1. Install the provider with [Composer](https://getcomposer.org/)
+
+```bash
+composer require configcat/openfeature-provider
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes the SDK key and an optional `array` argument containing the additional configuration options for the [ConfigCat PHP SDK](../../php/#creating-the-configcat-client):
+
+```php
+use ConfigCat\ClientOptions;
+use ConfigCat\Log\LogLevel;
+use ConfigCat\OpenFeature\ConfigCatProvider;
+use OpenFeature\implementation\flags\Attributes;
+use OpenFeature\implementation\flags\EvaluationContext;
+use OpenFeature\OpenFeatureAPI;
+
+// Acquire an OpenFeature API instance.
+$api = OpenFeatureAPI::getInstance();
+
+// Build options for the ConfigCat SDK.
+$options = [
+  ClientOptions::LOG_LEVEL => LogLevel::WARNING,
+  ClientOptions::CACHE_REFRESH_INTERVAL => 5,
+  //...
+];
+
+// Configure the provider.
+$api->setProvider(new ConfigCatProvider('#YOUR-SDK-KEY#', $options));
+
+// Create a client.
+$client = $api->getClient();
+```
+
+For more information about all the configuration options, see the [PHP SDK documentation](../../php/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```php
+$isAwesomeFeatureEnabled = $client->getBooleanValue('isAwesomeFeatureEnabled', false);
+if(is_bool($isAwesomeFeatureEnabled) && $isAwesomeFeatureEnabled) {
+    doTheNewThing();
+} else {
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../php/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targetingKey`     | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```php
+$context = new EvaluationContext('#SOME-USER-ID#', new Attributes([
+    'Email' => 'configcat@example.com',
+    'Country' => 'CountryID',
+    'Rating' => 4.5,
+    'RegisteredAt' => new DateTimeImmutable('2023-11-22T12:34:56.0000000Z'),
+    'Roles' => ['Role1', 'Role2']
+]));
+
+$isAwesomeFeatureEnabled = $client->getBooleanValue('isAwesomeFeatureEnabled', false, $context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/configcat/openfeature-php/tree/main/samples/ConfigCatProvider" target="_blank">Sample PHP App</a>
+- <a href="https://github.com/configcat/php-openfeature" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://packagist.org/packages/configcat/openfeature-provider" target="_blank">ConfigCat OpenFeature Provider on packagist.org</a>

--- a/website/docs/sdk-reference/openfeature/python.mdx
+++ b/website/docs/sdk-reference/openfeature/python.mdx
@@ -47,7 +47,7 @@ For more information about all the configuration options, see the [Python SDK do
 
 ### 3. Evaluate your feature flag
 
-```rust
+```python
 is_awesome_feature_enabled = client.get_boolean_value("isAwesomeFeatureEnabled", False)
 if is_awesome_feature_enabled:
     do_the_new_thing()
@@ -58,7 +58,7 @@ else:
 ## Evaluation Context
 
 An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
-The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../php/#user-object).
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../python/#user-object).
 
 The following table shows how the different context attributes are mapped to User Object attributes.
 

--- a/website/docs/sdk-reference/openfeature/python.mdx
+++ b/website/docs/sdk-reference/openfeature/python.mdx
@@ -1,0 +1,92 @@
+---
+id: python
+title: OpenFeature Provider for Python
+description: ConfigCat OpenFeature Provider for Python. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Python SDK.
+---
+
+[![CI](https://github.com/configcat/openfeature-python/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/configcat/openfeature-python/actions/workflows/ci.yml) 
+[![PyPI](https://img.shields.io/pypi/v/configcat-openfeature-provider.svg)](https://pypi.python.org/pypi/configcat-openfeature-provider)
+[![PyPI](https://img.shields.io/pypi/pyversions/configcat-openfeature-provider.svg)](https://pypi.python.org/pypi/configcat-openfeature-provider)
+
+<a href="https://github.com/configcat/openfeature-python" target="_blank">ConfigCat OpenFeature Provider for Python on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+```bash
+pip install configcat-openfeature-provider
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes the SDK key and an optional `ConfigCatOptions` argument containing the additional 
+configuration options for the [ConfigCat Python SDK](../../python/#creating-the-configcat-client):
+
+```python
+from configcatclient import ConfigCatOptions, PollingMode
+from openfeature import api
+from configcat_openfeature_provider import ConfigCatProvider
+
+# Configure the OpenFeature API with the ConfigCat provider.
+api.set_provider(
+    ConfigCatProvider(
+        "#YOUR-SDK-KEY#",
+        # Configure the ConfigCat SDK.
+        ConfigCatOptions(
+            polling_mode=PollingMode.auto_poll(60),
+        ),
+    )
+)
+
+# Create a client.
+client = api.get_client()
+```
+
+For more information about all the configuration options, see the [Python SDK documentation](../../python/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```rust
+is_awesome_feature_enabled = client.get_boolean_value("isAwesomeFeatureEnabled", False)
+if is_awesome_feature_enabled:
+    do_the_new_thing()
+else:
+    do_the_old_thing()
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../php/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targeting_key`    | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```python
+context = EvaluationContext(
+    targeting_key='#SOME-USER-ID#',
+    attributes={
+        'Email': 'configcat@example.com',
+        'Country': 'CountryID',
+        'Rating': 4.5,
+        'RegisteredAt': datetime.fromisoformat('2023-11-22 12:34:56 +00:00'),
+        'Roles': [ 'Role1', 'Role2' ]
+    }
+)
+
+is_awesome_feature_enabled = client.get_boolean_value('isAwesomeFeatureEnabled', False, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/configcat/openfeature-python" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://pypi.org/project/configcat-openfeature-provider/" target="_blank">ConfigCat OpenFeature Provider in PyPI</a>

--- a/website/docs/sdk-reference/openfeature/rust.mdx
+++ b/website/docs/sdk-reference/openfeature/rust.mdx
@@ -4,6 +4,10 @@ title: OpenFeature Provider for Rust
 description: ConfigCat OpenFeature Provider for Rust. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Rust SDK.
 ---
 
+[![Build Status](https://github.com/configcat/openfeature-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/configcat/openfeature-rust/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/configcat-openfeature-provider.svg?logo=rust)](https://crates.io/crates/configcat-openfeature-provider)
+[![docs.rs](https://img.shields.io/badge/docs.rs-configcat_openfeature_provider-66c2a5?logo=docs.rs)](https://docs.rs/configcat-openfeature-provider)
+
 <a href="https://github.com/configcat/openfeature-rust" target="_blank">ConfigCat OpenFeature Provider for Rust on GitHub</a>
 
 ## Getting started
@@ -90,7 +94,6 @@ let context = EvaluationContext::default()
     .with_custom_field("Email", "configcat@example.com")
     .with_custom_field("Country", "CountryID")
     .with_custom_field("Rating", 4.5)
-    .with_custom_field("RegisteredAt", DateTime::from_str("2023-06-14T15:27:15.8440000Z").unwrap())
     .with_custom_field("Roles", ["Role1", "Role2"]);
 
 let is_awesome_feature_enabled = client

--- a/website/docs/sdk-reference/openfeature/rust.mdx
+++ b/website/docs/sdk-reference/openfeature/rust.mdx
@@ -1,0 +1,107 @@
+---
+id: rust
+title: OpenFeature Provider for Rust
+description: ConfigCat OpenFeature Provider for Rust. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Rust SDK.
+---
+
+<a href="https://github.com/configcat/openfeature-rust" target="_blank">ConfigCat OpenFeature Provider for Rust on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+Run the following Cargo command in your project directory:
+```shell
+cargo add configcat-openfeature-provider
+```
+
+Or add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+configcat-openfeature-provider = "0.1"
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider` needs a pre-configured [ConfigCat Rust SDK](../../rust/#creating-the-configcat-client) client:
+
+```rust
+use std::time::Duration;
+use configcat::{Client, PollingMode};
+use open_feature::OpenFeature;
+use configcat_openfeature_provider::ConfigCatProvider;
+
+#[tokio::main]
+async fn main() {
+    // Acquire an OpenFeature API instance.
+    let mut api = OpenFeature::singleton_mut().await;
+
+    // Configure the ConfigCat SDK.
+    let configcat_client = Client::builder("<YOUR-CONFIGCAT-SDK-KEY>")
+        .polling_mode(PollingMode::AutoPoll(Duration::from_secs(60)))
+        .build()
+        .unwrap();
+
+    // Configure the provider.
+    api.set_provider(ConfigCatProvider::new(configcat_client)).await;
+
+    // Create a client.
+    let client = api.create_client();
+}
+```
+
+For more information about all the configuration options, see the [Rust SDK documentation](../../rust/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```rust
+let is_awesome_feature_enabled = client
+    .get_bool_value("isAwesomeFeatureEnabled", None, None)
+    .await
+    .unwrap_or(false);
+
+if is_awesome_feature_enabled {
+    do_the_new_thing();
+} else {
+    do_the_old_thing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../rust/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targeting_key`    | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```rust
+let context = EvaluationContext::default()
+    .with_targeting_key("#SOME-USER-ID#")
+    .with_custom_field("Email", "configcat@example.com")
+    .with_custom_field("Country", "CountryID")
+    .with_custom_field("Rating", 4.5)
+    .with_custom_field("RegisteredAt", DateTime::from_str("2023-06-14T15:27:15.8440000Z").unwrap())
+    .with_custom_field("Roles", ["Role1", "Role2"]);
+
+let is_awesome_feature_enabled = client
+    .get_bool_value("isAwesomeFeatureEnabled", Some(&context), None)
+    .await
+    .unwrap_or(false);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/configcat/openfeature-rust/tree/main/examples" target="_blank">Sample Rust App</a>
+- <a href="https://github.com/configcat/openfeature-rust" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://crates.io/crates/configcat-openfeature-provider" target="_blank">ConfigCat OpenFeature Provider on crates.io</a>
+- <a href="https://docs.rs/configcat-openfeature-provider/latest/configcat_openfeature_provider" target="_blank">ConfigCat OpenFeature Provider on docs.rs</a>

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -220,39 +220,40 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'sdk-reference/rust', label: 'Rust' },
         { type: 'doc', id: 'sdk-reference/ios', label: 'Swift (iOS)' },
         { type: 'doc', id: 'sdk-reference/unreal', label: 'Unreal Engine' },
+        
+      ],
+    },
+    {
+      label: 'OpenFeature Providers',
+      type: 'category',
+      link: { type: 'doc', id: 'sdk-reference/openfeature/overview' },
+      items: [
+        { type: 'doc', id: 'sdk-reference/openfeature/dotnet', label: '.NET' },
+        { type: 'doc', id: 'sdk-reference/openfeature/go', label: 'Go' },
+        { type: 'doc', id: 'sdk-reference/openfeature/java', label: 'Java' },
+        { type: 'doc', id: 'sdk-reference/openfeature/js', label: 'JavaScript' },
+        { type: 'doc', id: 'sdk-reference/openfeature/node', label: 'Node.js' },
+        { type: 'doc', id: 'sdk-reference/openfeature/php', label: 'PHP' },
+        { type: 'doc', id: 'sdk-reference/openfeature/python', label: 'Python' },
+        { type: 'doc', id: 'sdk-reference/openfeature/rust', label: 'Rust' },
+      ],
+    },
+    {
+      'Community Maintained': [
         {
-          'Community Maintained': [
-            {
-              type: 'doc',
-              id: 'sdk-reference/community/laravel',
-              label: 'PHP (Laravel)',
-            },
-            {
-              type: 'doc',
-              id: 'sdk-reference/community/deno',
-              label: 'TypeScript (Deno)',
-            },
-            {
-              type: 'doc',
-              id: 'sdk-reference/community/vue',
-              label: 'JavaScript (Vue.js)',
-            },
-          ],
+          type: 'doc',
+          id: 'sdk-reference/community/laravel',
+          label: 'PHP (Laravel)',
         },
         {
-          label: 'OpenFeature Providers',
-          type: 'category',
-          link: { type: 'doc', id: 'sdk-reference/openfeature/overview' },
-          items: [
-            { type: 'doc', id: 'sdk-reference/openfeature/dotnet', label: '.NET' },
-            { type: 'doc', id: 'sdk-reference/openfeature/go', label: 'Go' },
-            { type: 'doc', id: 'sdk-reference/openfeature/java', label: 'Java' },
-            { type: 'doc', id: 'sdk-reference/openfeature/js', label: 'JavaScript' },
-            { type: 'doc', id: 'sdk-reference/openfeature/node', label: 'Node.js' },
-            { type: 'doc', id: 'sdk-reference/openfeature/php', label: 'PHP' },
-            { type: 'doc', id: 'sdk-reference/openfeature/python', label: 'Python' },
-            { type: 'doc', id: 'sdk-reference/openfeature/rust', label: 'Rust' },
-          ],
+          type: 'doc',
+          id: 'sdk-reference/community/deno',
+          label: 'TypeScript (Deno)',
+        },
+        {
+          type: 'doc',
+          id: 'sdk-reference/community/vue',
+          label: 'JavaScript (Vue.js)',
         },
       ],
     },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -239,6 +239,21 @@ const sidebars: SidebarsConfig = {
             },
           ],
         },
+        {
+          label: 'OpenFeature Providers',
+          type: 'category',
+          link: { type: 'doc', id: 'sdk-reference/openfeature/overview' },
+          items: [
+            { type: 'doc', id: 'sdk-reference/openfeature/dotnet', label: '.NET' },
+            { type: 'doc', id: 'sdk-reference/openfeature/go', label: 'Go' },
+            { type: 'doc', id: 'sdk-reference/openfeature/java', label: 'Java' },
+            { type: 'doc', id: 'sdk-reference/openfeature/js', label: 'JavaScript' },
+            { type: 'doc', id: 'sdk-reference/openfeature/node', label: 'Node.js' },
+            { type: 'doc', id: 'sdk-reference/openfeature/php', label: 'PHP' },
+            { type: 'doc', id: 'sdk-reference/openfeature/python', label: 'Python' },
+            { type: 'doc', id: 'sdk-reference/openfeature/rust', label: 'Rust' },
+          ],
+        },
       ],
     },
   ]

--- a/website/versioned_docs/version-V1/sdk-reference/android.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/android.mdx
@@ -265,8 +265,8 @@ User user = User.newBuilder().build("john@example.com");
 
 ```java
 java.util.Map<String,String> customAttributes = new java.util.HashMap<String,String>();
-    customAttributes.put("SubscriptionType", "Pro");
-    customAttributes.put("UserRole", "Admin");
+customAttributes.put("SubscriptionType", "Pro");
+customAttributes.put("UserRole", "Admin");
 
 User user = User.newBuilder()
     .email("john@example.com")
@@ -506,7 +506,7 @@ List<EvaluationDetails<?>> allValueDetails = client.getAllValueDetails(user);
 ```java
 User user = User.newBuilder().build("#UNIQUE-USER-IDENTIFIER#");
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#");
-        client.getAllValueDetailsAsync(user).thenAccept(allValueDetails -> { });
+client.getAllValueDetailsAsync(user).thenAccept(allValueDetails -> { });
 ```
 
 ## Cache
@@ -519,7 +519,7 @@ The `SharedPreferencesCache` implementation uses the Android `SharedPreferences`
 
 ```java
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options -> {
-        options.cache(new SharedPreferencesCache(getApplicationContext())); // Use ConfigCat's shared preferences cache.
+    options.cache(new SharedPreferencesCache(getApplicationContext())); // Use ConfigCat's shared preferences cache.
 });
 ```
 

--- a/website/versioned_docs/version-V1/sdk-reference/go.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/go.mdx
@@ -116,7 +116,7 @@ If you want to use multiple SDK Keys in the same application, create only one _C
 
 ## Anatomy of `Get[TYPE]Value()`
 
-Basically all of the value evaluator methods share the same signature, they only differ in their served value type. `GetBoolValue()` is for evaluating feature flags, `GetIntValue()` and `GetFloatValue()` are for numeric and `GetStringValue()` is for textual settings.
+All feature flag evaluator methods share the same signature, they only differ in their served value type. `GetBoolValue()` is for evaluating feature flags, `GetIntValue()` and `GetFloatValue()` are for numeric and `GetStringValue()` is for textual settings.
 
 | Parameters     | Description                                                                                        |
 | -------------- | -------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-V1/sdk-reference/java.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/java.mdx
@@ -270,8 +270,8 @@ User user = User.newBuilder().build("john@example.com");
 
 ```java
 java.util.Map<String,String> customAttributes = new java.util.HashMap<String,String>();
-    customAttributes.put("SubscriptionType", "Pro");
-    customAttributes.put("UserRole", "Admin");
+customAttributes.put("SubscriptionType", "Pro");
+customAttributes.put("UserRole", "Admin");
 
 User user = User.newBuilder()
     .email("john@example.com")
@@ -356,7 +356,7 @@ Use the `cacheRefreshIntervalInSeconds` option parameter of the `PollingModes.la
 
 ```java
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options -> {
-        options.pollingMode(PollingModes.lazyLoad(60 /* the cache will expire in 120 seconds */));
+    options.pollingMode(PollingModes.lazyLoad(60 /* the cache will expire in 120 seconds */));
 });
 ```
 
@@ -374,7 +374,7 @@ Manual polling gives you full control over when the `config JSON` (with the sett
 
 ```java
 ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options ->{
-        options.pollingMode(PollingModes.manualPoll());
+    options.pollingMode(PollingModes.manualPoll());
 });
 
 client.forceRefresh();
@@ -580,7 +580,7 @@ map.put("doubleSetting", 3.14);
 map.put("stringSetting", "test");
 
 ConfigCatClient client = ConfigCatClient.get("localhost", options -> {
-        options.flagOverrides(OverrideDataSourceBuilder.map(map), OverrideBehaviour.LOCAL_ONLY)
+    options.flagOverrides(OverrideDataSourceBuilder.map(map), OverrideBehaviour.LOCAL_ONLY)
 });
 ```
 

--- a/website/versioned_docs/version-V1/sdk-reference/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/js.mdx
@@ -55,8 +55,8 @@ import * as configcat from 'configcat-js';
 ```html
 <script
   type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/configcat-js@latest/dist/configcat.min.js"
-></script>
+  src="https://cdn.jsdelivr.net/npm/configcat-js@latest/dist/configcat.min.js">
+</script>
 ```
 
 </TabItem>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/dotnet.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/dotnet.mdx
@@ -1,0 +1,108 @@
+---
+id: dotnet
+title: OpenFeature Provider for .NET
+description: ConfigCat OpenFeature Provider for .NET. This is a step-by-step guide on how to use ConfigCat with the OpenFeature .NET SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.ConfigCat" target="_blank">ConfigCat OpenFeature Provider for .NET on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+<Tabs groupId="dotnet-install">
+<TabItem value="Powershell / NuGet Package Manager Console" label="Powershell / NuGet Package Manager Console">
+
+```powershell
+Install-Package OpenFeature.Contrib.Providers.ConfigCat
+```
+
+</TabItem>
+<TabItem value=".NET CLI" label=".NET CLI">
+
+```bash
+dotnet add package OpenFeature.Contrib.Providers.ConfigCat
+```
+
+</TabItem>
+<TabItem value="Package Reference" label="Package Reference">
+
+```xml
+<PackageReference Include="OpenFeature.Contrib.Providers.ConfigCat" />
+```
+
+</TabItem>
+</Tabs>
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes the SDK key and an optional `ConfigCatClientOptions` argument containing the additional configuration options for the [ConfigCat .NET SDK](../../dotnet/#creating-the-configcat-client):
+
+```cs
+using OpenFeature.Contrib.Providers.ConfigCat;
+
+// Build options for the ConfigCat SDK.
+var options = new ConfigCatClientOptions
+{
+    PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(60));
+    Logger = new ConsoleLogger(LogLevel.Warning);
+    // ...
+};
+
+// Configure the provider.
+OpenFeature.Api.Instance.SetProvider(new ConfigCatProvider("#YOUR-SDK-KEY#", options));
+
+// Create a client.
+var client = OpenFeature.Api.Instance.GetClient();
+```
+
+For more information about all the configuration options, see the [.NET SDK documentation](../../dotnet/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```cs
+var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false);
+if(isAwesomeFeatureEnabled)
+{
+    doTheNewThing();
+}
+else
+{
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../dotnet/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `Id`/`Identifier`  | `Identifier` | &#9745;  | 
+| `Email`            | `Email`      |          | 
+| `Country`          | `Country`    |          | 
+| Any other          | `Custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```cs
+var context = new EvaluationContext()
+    .Set("Id", "#SOME-USER-ID#")
+    .Set("Email", "configcat@example.com")
+    .Set("Country", "CountryID")
+    .Set("Rating", 4.5)
+    .Set("RegisteredAt", DateTime.Parse("2023-11-22 12:34:56 +00:00", CultureInfo.InvariantCulture))
+    .Build();
+
+var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.ConfigCat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://www.nuget.org/packages/OpenFeature.Contrib.Providers.ConfigCat" target="_blank">ConfigCat OpenFeature Provider on nuget.org</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
@@ -43,7 +43,7 @@ For more information about all the configuration options, see the [Go SDK docume
 
 ### 3. Evaluate your feature flag
 
-```rust
+```go
 isAwesomeFeatureEnabled, err := client.BooleanValue(
     context.Background(), "isAwesomeFeatureEnabled", false, openfeature.EvaluationContext{},
 )

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
@@ -1,0 +1,91 @@
+---
+id: go
+title: OpenFeature Provider for Go
+description: ConfigCat OpenFeature Provider for Go. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Go SDK.
+---
+
+<a href="https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider for Go on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+```bash
+go get github.com/open-feature/go-sdk-contrib/providers/configcat
+```
+
+### 2. Initialize the provider
+
+The ConfigCat Provider needs a pre-configured [ConfigCat Go SDK](../../go/#creating-the-configcat-client) client:
+
+```go
+import (
+    "context"
+
+    sdk "github.com/configcat/go-sdk/v9"
+    configcat "github.com/open-feature/go-sdk-contrib/providers/configcat/pkg"
+    "github.com/open-feature/go-sdk/openfeature"
+)
+
+// Configure the ConfigCat SDK.
+configcatClient := sdk.NewCustomClient(sdk.Config{SDKKey: "#YOUR-SDK-KEY#",
+    PollingMode: sdk.AutoPoll,
+    PollInterval: time.Second * 60})
+
+// Configure the provider.
+openfeature.SetProvider(configcat.NewProvider(configcatClient))
+
+# Create a client.
+client := openfeature.NewClient("app")
+```
+
+For more information about all the configuration options, see the [Go SDK documentation](../../go/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```rust
+isAwesomeFeatureEnabled, err := client.BooleanValue(
+    context.Background(), "isAwesomeFeatureEnabled", false, openfeature.EvaluationContext{},
+)
+
+if err == nil && isAwesomeFeatureEnabled {
+    doTheNewThing()
+} else {
+    doTheOldThing()
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../go/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context              | User Object  | Required |
+| ------------------------------- | ------------ | -------- |
+| `openfeature.TargetingKey`      | `Identifier` | &#9745;  | 
+| `configcat.EmailKey`            | `Email`      |          | 
+| `configcat.CountryKey`          | `Country`    |          | 
+| Any other                       | `Custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```go
+registeredAt, _ := time.Parse(time.DateTime, "2023-11-22 12:34:56")
+context := openfeature.NewEvaluationContext("#SOME-USER-ID#", map[string]any{
+    configcat.EmailKey: "configcat@example.com",
+    configcat.CountryKey: "CountryID",
+    "Rating": 4.5,
+    "RegisteredAt": registeredAt,
+    "Roles": []string{"Role1","Role2"},
+})
+
+isAwesomeFeatureEnabled, err := client.BooleanValue(
+    context.Background(), "isAwesomeFeatureEnabled", false, context,
+)
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/java.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/java.mdx
@@ -58,7 +58,7 @@ For more information about all the configuration options, see the [Java SDK docu
 
 ### 3. Evaluate your feature flag
 
-```cs
+```java
 boolean isAwesomeFeatureEnabled = client.getBooleanValue("isAwesomeFeatureEnabled", false);
 if(isAwesomeFeatureEnabled)
 {
@@ -86,7 +86,7 @@ The following table shows how the different context attributes are mapped to Use
 
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
-```cs
+```java
 MutableContext evaluationContext = new MutableContext();
 evaluationContext.setTargetingKey("#SOME-USER-ID#");
 evaluationContext.add("Email", "configcat@example.com");

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/java.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/java.mdx
@@ -1,0 +1,102 @@
+---
+id: java
+title: OpenFeature Provider for Java
+description: ConfigCat OpenFeature Provider for Java. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Java SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/java-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider for Java on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+<Tabs groupId="java-install">
+<TabItem value="Gradle" label="Gradle">
+
+```groovy title="build.gradle"
+dependencies {
+    implementation 'dev.openfeature.contrib.providers:configcat:0.0.4'
+}
+```
+
+</TabItem>
+<TabItem value="Maven" label="Maven">
+
+```xml title="pom.xml"
+<dependency>
+  <groupId>dev.openfeature.contrib.providers</groupId>
+  <artifactId>configcat</artifactId>
+  <version>0.0.4</version>
+</dependency>
+```
+
+</TabItem>
+</Tabs>
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes a `ConfigCatProviderConfig` argument containing the configuration options for the [ConfigCat Java SDK](../../java/#creating-the-configcat-client):
+
+```java
+// Build options for the ConfigCat SDK.
+ConfigCatProviderConfig configCatProviderConfig = ConfigCatProviderConfig.builder()
+    .sdkKey("#YOUR-SDK-KEY#")
+    .pollingMode(PollingModes.autoPoll())
+    .logLevel(LogLevel.WARNING)
+    .build();
+
+// Configure the provider.
+OpenFeatureAPI.getInstance().setProviderAndWait(new ConfigCatProvider(configCatProviderConfig));
+
+// Create a client.
+Client client = OpenFeatureAPI.getInstance().getClient();
+```
+
+For more information about all the configuration options, see the [Java SDK documentation](../../java/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```cs
+boolean isAwesomeFeatureEnabled = client.getBooleanValue("isAwesomeFeatureEnabled", false);
+if(isAwesomeFeatureEnabled)
+{
+    doTheNewThing();
+}
+else
+{
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../java/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `TargetingKey`     | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```cs
+MutableContext evaluationContext = new MutableContext();
+evaluationContext.setTargetingKey("#SOME-USER-ID#");
+evaluationContext.add("Email", "configcat@example.com");
+evaluationContext.add("Country", "CountryID");
+evaluationContext.add("Rating", 4.5);
+
+boolean isAwesomeFeatureEnabled = client.getBooleanValue("isAwesomeFeatureEnabled", false, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/java-sdk-contrib/tree/main/providers/configcat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://search.maven.org/artifact/dev.openfeature.contrib.providers/configcat" target="_blank">ConfigCat OpenFeature Provider on Maven Central</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
@@ -1,0 +1,97 @@
+---
+id: js
+title: OpenFeature Provider for JavaScript
+description: ConfigCat OpenFeature Provider for JavaScript. This is a step-by-step guide on how to use ConfigCat with the OpenFeature JavaScript SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat-web" target="_blank">ConfigCat OpenFeature Provider for JavaScript on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+<Tabs groupId="js-install">
+<TabItem value="NPM" label="NPM">
+
+```bash
+npm i @openfeature/config-cat-web-provider
+```
+
+</TabItem>
+<TabItem value="CDN" label="CDN">
+
+```html
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js"
+></script>
+```
+
+</TabItem>
+</Tabs>
+### 2. Initialize the provider
+
+The `ConfigCatWebProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat JavaScript SDK](../../js/#creating-the-configcat-client):
+
+```js
+import { ConfigCatWebProvider } from '@openfeature/config-cat-web-provider';
+
+// Build options for the ConfigCat SDK.
+const options = { 
+    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+    // ...
+}
+
+// Configure the provider.
+OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', options));
+ 
+// Create a client.
+const client = OpenFeature.getClient();
+```
+
+For more information about all the configuration options, see the [JavaScript SDK documentation](../../js/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```js
+const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);
+if(isAwesomeFeatureEnabled) {
+    doTheNewThing();
+} else {
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../js/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targetingKey`     | `identifier` | &#9745;  | 
+| `email`            | `email`      |          | 
+| `country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```js
+await OpenFeature.setContext({ 
+    targetingKey: '#SOME-USER-ID#', 
+    email: 'configcat@example.com', 
+    country: 'CountryID',
+});
+
+const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat-web" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://www.npmjs.com/package/@openfeature/config-cat-web-provider" target="_blank">ConfigCat OpenFeature Provider in NPM</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
@@ -26,8 +26,8 @@ npm i @openfeature/config-cat-web-provider
 ```html
 <script
   type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js"
-></script>
+  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js">
+</script>
 ```
 
 </TabItem>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/node.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/node.mdx
@@ -1,0 +1,82 @@
+---
+id: node
+title: OpenFeature Provider for Node.js
+description: ConfigCat OpenFeature Provider for Node. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Node.js SDK.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat" target="_blank">ConfigCat OpenFeature Provider for Node.js on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+```bash
+npm i @openfeature/config-cat-provider
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat Node.js SDK](../../node/#creating-the-configcat-client):
+
+```js
+import { ConfigCatProvider } from '@openfeature/config-cat-provider';
+
+// Build options for the ConfigCat SDK.
+const options = { 
+    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+    // ...
+}
+
+// Configure the provider.
+OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', PollingMode.AutoPoll, options));
+ 
+// Create a client.
+const client = OpenFeature.getClient();
+```
+
+For more information about all the configuration options, see the [Node.js SDK documentation](../../node/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```js
+const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false);
+if(isAwesomeFeatureEnabled) {
+    doTheNewThing();
+} else {
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../node/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targetingKey`     | `identifier` | &#9745;  | 
+| `email`            | `email`      |          | 
+| `country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```js
+const context = { 
+    targetingKey: '#SOME-USER-ID#', 
+    email: 'configcat@example.com', 
+    country: 'CountryID',
+};
+
+const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/config-cat" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://www.npmjs.com/package/@openfeature/config-cat-provider" target="_blank">ConfigCat OpenFeature Provider in NPM</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/overview.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/overview.mdx
@@ -1,0 +1,20 @@
+---
+id: overview
+title: OpenFeature Providers
+description: List of all supported OpenFeature Providers.
+---
+
+OpenFeature is an open specification that provides a vendor-agnostic, community-driven API for feature flagging. 
+
+OpenFeature providers are the abstraction between an OpenFeature SDK and an underlying flag management system like ConfigCat. To learn more, see the [OpenFeature documentation](https://openfeature.dev/docs/reference/intro).
+
+ConfigCat offers providers for the following platforms supported by OpenFeature SDKs:
+
+- [.NET](./dotnet.mdx)
+- [Go](./go.mdx)
+- [Java](./java.mdx)
+- [JavaScript](./js.mdx)
+- [Node](./node.mdx)
+- [PHP](./php.mdx)
+- [Python](./python.mdx)
+- [Rust](./rust.mdx)

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/php.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/php.mdx
@@ -1,0 +1,98 @@
+---
+id: php
+title: OpenFeature Provider for PHP
+description: ConfigCat OpenFeature Provider for PHP. This is a step-by-step guide on how to use ConfigCat with the OpenFeature PHP SDK.
+---
+
+[![Build Status](https://github.com/configcat/openfeature-php/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/configcat/openfeature-php/actions/workflows/ci.yml)
+[![Latest Stable Version](https://poser.pugx.org/configcat/openfeature-provider/version)](https://packagist.org/packages/configcat/openfeature-provider)
+[![Total Downloads](https://poser.pugx.org/configcat/openfeature-provider/downloads)](https://packagist.org/packages/configcat/openfeature-provider)
+
+<a href="https://github.com/configcat/openfeature-php" target="_blank">ConfigCat OpenFeature Provider for PHP on GitHub</a>
+
+## Requirements
+- PHP >= 8.1
+
+## Getting started
+
+### 1. Install the provider with [Composer](https://getcomposer.org/)
+
+```bash
+composer require configcat/openfeature-provider
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes the SDK key and an optional `array` argument containing the additional configuration options for the [ConfigCat PHP SDK](../../php/#creating-the-configcat-client):
+
+```php
+use ConfigCat\ClientOptions;
+use ConfigCat\Log\LogLevel;
+use ConfigCat\OpenFeature\ConfigCatProvider;
+use OpenFeature\implementation\flags\Attributes;
+use OpenFeature\implementation\flags\EvaluationContext;
+use OpenFeature\OpenFeatureAPI;
+
+// Acquire an OpenFeature API instance.
+$api = OpenFeatureAPI::getInstance();
+
+// Build options for the ConfigCat SDK.
+$options = [
+  ClientOptions::LOG_LEVEL => LogLevel::WARNING,
+  ClientOptions::CACHE_REFRESH_INTERVAL => 5,
+  //...
+];
+
+// Configure the provider.
+$api->setProvider(new ConfigCatProvider('#YOUR-SDK-KEY#', $options));
+
+// Create a client.
+$client = $api->getClient();
+```
+
+For more information about all the configuration options, see the [PHP SDK documentation](../../php/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```php
+$isAwesomeFeatureEnabled = $client->getBooleanValue('isAwesomeFeatureEnabled', false);
+if(is_bool($isAwesomeFeatureEnabled) && $isAwesomeFeatureEnabled) {
+    doTheNewThing();
+} else {
+    doTheOldThing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../php/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targetingKey`     | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```php
+$context = new EvaluationContext('#SOME-USER-ID#', new Attributes([
+    'Email' => 'configcat@example.com',
+    'Country' => 'CountryID',
+    'Rating' => 4.5,
+    'RegisteredAt' => new DateTimeImmutable('2023-11-22T12:34:56.0000000Z'),
+    'Roles' => ['Role1', 'Role2']
+]));
+
+$isAwesomeFeatureEnabled = $client->getBooleanValue('isAwesomeFeatureEnabled', false, $context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/configcat/openfeature-php/tree/main/samples/ConfigCatProvider" target="_blank">Sample PHP App</a>
+- <a href="https://github.com/configcat/php-openfeature" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://packagist.org/packages/configcat/openfeature-provider" target="_blank">ConfigCat OpenFeature Provider on packagist.org</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/python.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/python.mdx
@@ -47,7 +47,7 @@ For more information about all the configuration options, see the [Python SDK do
 
 ### 3. Evaluate your feature flag
 
-```rust
+```python
 is_awesome_feature_enabled = client.get_boolean_value("isAwesomeFeatureEnabled", False)
 if is_awesome_feature_enabled:
     do_the_new_thing()
@@ -58,7 +58,7 @@ else:
 ## Evaluation Context
 
 An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
-The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../php/#user-object).
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../python/#user-object).
 
 The following table shows how the different context attributes are mapped to User Object attributes.
 

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/python.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/python.mdx
@@ -1,0 +1,92 @@
+---
+id: python
+title: OpenFeature Provider for Python
+description: ConfigCat OpenFeature Provider for Python. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Python SDK.
+---
+
+[![CI](https://github.com/configcat/openfeature-python/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/configcat/openfeature-python/actions/workflows/ci.yml) 
+[![PyPI](https://img.shields.io/pypi/v/configcat-openfeature-provider.svg)](https://pypi.python.org/pypi/configcat-openfeature-provider)
+[![PyPI](https://img.shields.io/pypi/pyversions/configcat-openfeature-provider.svg)](https://pypi.python.org/pypi/configcat-openfeature-provider)
+
+<a href="https://github.com/configcat/openfeature-python" target="_blank">ConfigCat OpenFeature Provider for Python on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+```bash
+pip install configcat-openfeature-provider
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider` constructor takes the SDK key and an optional `ConfigCatOptions` argument containing the additional 
+configuration options for the [ConfigCat Python SDK](../../python/#creating-the-configcat-client):
+
+```python
+from configcatclient import ConfigCatOptions, PollingMode
+from openfeature import api
+from configcat_openfeature_provider import ConfigCatProvider
+
+# Configure the OpenFeature API with the ConfigCat provider.
+api.set_provider(
+    ConfigCatProvider(
+        "#YOUR-SDK-KEY#",
+        # Configure the ConfigCat SDK.
+        ConfigCatOptions(
+            polling_mode=PollingMode.auto_poll(60),
+        ),
+    )
+)
+
+# Create a client.
+client = api.get_client()
+```
+
+For more information about all the configuration options, see the [Python SDK documentation](../../python/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```rust
+is_awesome_feature_enabled = client.get_boolean_value("isAwesomeFeatureEnabled", False)
+if is_awesome_feature_enabled:
+    do_the_new_thing()
+else:
+    do_the_old_thing()
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../php/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targeting_key`    | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```python
+context = EvaluationContext(
+    targeting_key='#SOME-USER-ID#',
+    attributes={
+        'Email': 'configcat@example.com',
+        'Country': 'CountryID',
+        'Rating': 4.5,
+        'RegisteredAt': datetime.fromisoformat('2023-11-22 12:34:56 +00:00'),
+        'Roles': [ 'Role1', 'Role2' ]
+    }
+)
+
+is_awesome_feature_enabled = client.get_boolean_value('isAwesomeFeatureEnabled', False, context);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/configcat/openfeature-python" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://pypi.org/project/configcat-openfeature-provider/" target="_blank">ConfigCat OpenFeature Provider in PyPI</a>

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/rust.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/rust.mdx
@@ -4,6 +4,10 @@ title: OpenFeature Provider for Rust
 description: ConfigCat OpenFeature Provider for Rust. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Rust SDK.
 ---
 
+[![Build Status](https://github.com/configcat/openfeature-rust/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/configcat/openfeature-rust/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/configcat-openfeature-provider.svg?logo=rust)](https://crates.io/crates/configcat-openfeature-provider)
+[![docs.rs](https://img.shields.io/badge/docs.rs-configcat_openfeature_provider-66c2a5?logo=docs.rs)](https://docs.rs/configcat-openfeature-provider)
+
 <a href="https://github.com/configcat/openfeature-rust" target="_blank">ConfigCat OpenFeature Provider for Rust on GitHub</a>
 
 ## Getting started
@@ -90,7 +94,6 @@ let context = EvaluationContext::default()
     .with_custom_field("Email", "configcat@example.com")
     .with_custom_field("Country", "CountryID")
     .with_custom_field("Rating", 4.5)
-    .with_custom_field("RegisteredAt", DateTime::from_str("2023-06-14T15:27:15.8440000Z").unwrap())
     .with_custom_field("Roles", ["Role1", "Role2"]);
 
 let is_awesome_feature_enabled = client

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/rust.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/rust.mdx
@@ -1,0 +1,107 @@
+---
+id: rust
+title: OpenFeature Provider for Rust
+description: ConfigCat OpenFeature Provider for Rust. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Rust SDK.
+---
+
+<a href="https://github.com/configcat/openfeature-rust" target="_blank">ConfigCat OpenFeature Provider for Rust on GitHub</a>
+
+## Getting started
+
+### 1. Install the provider
+
+Run the following Cargo command in your project directory:
+```shell
+cargo add configcat-openfeature-provider
+```
+
+Or add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+configcat-openfeature-provider = "0.1"
+```
+
+### 2. Initialize the provider
+
+The `ConfigCatProvider` needs a pre-configured [ConfigCat Rust SDK](../../rust/#creating-the-configcat-client) client:
+
+```rust
+use std::time::Duration;
+use configcat::{Client, PollingMode};
+use open_feature::OpenFeature;
+use configcat_openfeature_provider::ConfigCatProvider;
+
+#[tokio::main]
+async fn main() {
+    // Acquire an OpenFeature API instance.
+    let mut api = OpenFeature::singleton_mut().await;
+
+    // Configure the ConfigCat SDK.
+    let configcat_client = Client::builder("<YOUR-CONFIGCAT-SDK-KEY>")
+        .polling_mode(PollingMode::AutoPoll(Duration::from_secs(60)))
+        .build()
+        .unwrap();
+
+    // Configure the provider.
+    api.set_provider(ConfigCatProvider::new(configcat_client)).await;
+
+    // Create a client.
+    let client = api.create_client();
+}
+```
+
+For more information about all the configuration options, see the [Rust SDK documentation](../../rust/#creating-the-configcat-client).
+
+### 3. Evaluate your feature flag
+
+```rust
+let is_awesome_feature_enabled = client
+    .get_bool_value("isAwesomeFeatureEnabled", None, None)
+    .await
+    .unwrap_or(false);
+
+if is_awesome_feature_enabled {
+    do_the_new_thing();
+} else {
+    do_the_old_thing();
+}
+```
+
+## Evaluation Context
+
+An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.
+The ConfigCat provider translates these evaluation contexts to ConfigCat [User Objects](../../rust/#user-object).
+
+The following table shows how the different context attributes are mapped to User Object attributes.
+
+| Evaluation context | User Object  | Required |
+| ------------------ | ------------ | -------- |
+| `targeting_key`    | `identifier` | &#9745;  | 
+| `Email`            | `email`      |          | 
+| `Country`          | `country`    |          | 
+| Any other          | `custom`     |          | 
+
+To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
+
+```rust
+let context = EvaluationContext::default()
+    .with_targeting_key("#SOME-USER-ID#")
+    .with_custom_field("Email", "configcat@example.com")
+    .with_custom_field("Country", "CountryID")
+    .with_custom_field("Rating", 4.5)
+    .with_custom_field("RegisteredAt", DateTime::from_str("2023-06-14T15:27:15.8440000Z").unwrap())
+    .with_custom_field("Roles", ["Role1", "Role2"]);
+
+let is_awesome_feature_enabled = client
+    .get_bool_value("isAwesomeFeatureEnabled", Some(&context), None)
+    .await
+    .unwrap_or(false);
+```
+
+## Look under the hood
+
+- <a href="https://github.com/configcat/openfeature-rust/tree/main/examples" target="_blank">Sample Rust App</a>
+- <a href="https://github.com/configcat/openfeature-rust" target="_blank">ConfigCat OpenFeature Provider's repository on GitHub</a>
+- <a href="https://crates.io/crates/configcat-openfeature-provider" target="_blank">ConfigCat OpenFeature Provider on crates.io</a>
+- <a href="https://docs.rs/configcat-openfeature-provider/latest/configcat_openfeature_provider" target="_blank">ConfigCat OpenFeature Provider on docs.rs</a>

--- a/website/versioned_sidebars/version-V1-sidebars.json
+++ b/website/versioned_sidebars/version-V1-sidebars.json
@@ -369,40 +369,40 @@
           "type": "doc",
           "id": "sdk-reference/unreal",
           "label": "Unreal Engine"
+        }
+      ]
+    },
+    {
+      "label": "OpenFeature Providers",
+      "type": "category",
+      "link": { "type": "doc", "id": "sdk-reference/openfeature/overview" },
+      "items": [
+        { "type": "doc", "id": "sdk-reference/openfeature/dotnet", "label": ".NET" },
+        { "type": "doc", "id": "sdk-reference/openfeature/go", "label": "Go" },
+        { "type": "doc", "id": "sdk-reference/openfeature/java", "label": "Java" },
+        { "type": "doc", "id": "sdk-reference/openfeature/js", "label": "JavaScript" },
+        { "type": "doc", "id": "sdk-reference/openfeature/node", "label": "Node.js" },
+        { "type": "doc", "id": "sdk-reference/openfeature/php", "label": "PHP" },
+        { "type": "doc", "id": "sdk-reference/openfeature/python", "label": "Python" },
+        { "type": "doc", "id": "sdk-reference/openfeature/rust", "label": "Rust" }
+      ]
+    },
+    {
+      "Community Maintained": [
+        {
+          "type": "doc",
+          "id": "sdk-reference/community/laravel",
+          "label": "PHP (Laravel)"
         },
         {
-          "Community Maintained": [
-            {
-              "type": "doc",
-              "id": "sdk-reference/community/laravel",
-              "label": "PHP (Laravel)"
-            },
-            {
-              "type": "doc",
-              "id": "sdk-reference/community/deno",
-              "label": "TypeScript (Deno)"
-            },
-            {
-              "type": "doc",
-              "id": "sdk-reference/community/vue",
-              "label": "JavaScript (Vue.js)"
-            }
-          ]
+          "type": "doc",
+          "id": "sdk-reference/community/deno",
+          "label": "TypeScript (Deno)"
         },
         {
-          "label": "OpenFeature Providers",
-          "type": "category",
-          "link": { "type": "doc", "id": "sdk-reference/openfeature/overview" },
-          "items": [
-            { "type": "doc", "id": "sdk-reference/openfeature/dotnet", "label": ".NET" },
-            { "type": "doc", "id": "sdk-reference/openfeature/go", "label": "Go" },
-            { "type": "doc", "id": "sdk-reference/openfeature/java", "label": "Java" },
-            { "type": "doc", "id": "sdk-reference/openfeature/js", "label": "JavaScript" },
-            { "type": "doc", "id": "sdk-reference/openfeature/node", "label": "Node.js" },
-            { "type": "doc", "id": "sdk-reference/openfeature/php", "label": "PHP" },
-            { "type": "doc", "id": "sdk-reference/openfeature/python", "label": "Python" },
-            { "type": "doc", "id": "sdk-reference/openfeature/rust", "label": "Rust" }
-          ]
+          "type": "doc",
+          "id": "sdk-reference/community/vue",
+          "label": "JavaScript (Vue.js)"
         }
       ]
     }

--- a/website/versioned_sidebars/version-V1-sidebars.json
+++ b/website/versioned_sidebars/version-V1-sidebars.json
@@ -388,6 +388,21 @@
               "label": "JavaScript (Vue.js)"
             }
           ]
+        },
+        {
+          "label": "OpenFeature Providers",
+          "type": "category",
+          "link": { "type": "doc", "id": "sdk-reference/openfeature/overview" },
+          "items": [
+            { "type": "doc", "id": "sdk-reference/openfeature/dotnet", "label": ".NET" },
+            { "type": "doc", "id": "sdk-reference/openfeature/go", "label": "Go" },
+            { "type": "doc", "id": "sdk-reference/openfeature/java", "label": "Java" },
+            { "type": "doc", "id": "sdk-reference/openfeature/js", "label": "JavaScript" },
+            { "type": "doc", "id": "sdk-reference/openfeature/node", "label": "Node.js" },
+            { "type": "doc", "id": "sdk-reference/openfeature/php", "label": "PHP" },
+            { "type": "doc", "id": "sdk-reference/openfeature/python", "label": "Python" },
+            { "type": "doc", "id": "sdk-reference/openfeature/rust", "label": "Rust" }
+          ]
         }
       ]
     }


### PR DESCRIPTION
### Description

This PR adds a new `OpenFeature Providers` section under the `SDK References` menu that lists and documents all the ConfigCat providers.

### Notes for QA

- Docs -> SDKs -> SDK References -> OpenFeature Providers

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
