### PR TITLE
Fix .NET, JavaScript and Node.js OpenFeature provider code samples

### DIFF
--- a/website/docs/sdk-reference/dotnet.mdx
+++ b/website/docs/sdk-reference/dotnet.mdx
@@ -1,7 +1,7 @@
 ---
 id: dotnet
-title: .NET, .NET Core SDK Reference
-description: ConfigCat .NET, .NET Core SDK Reference. This is a step-by-step guide on how to use feature flags in your .NET, .NET Core application.
+title: .NET SDK Reference
+description: ConfigCat .NET SDK Reference. This is a step-by-step guide on how to use feature flags in your .NET application.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -956,7 +956,7 @@ Check out our Sample Applications how they use the _ConfigCat SDK_:
 See the following guides on how to use ConfigCat's .NET SDK:
 
 - <a href="https://configcat.com/blog/2022/11/25/feature-flags-in-net6/" target="_blank">.NET 6</a>
-- <a href="https://configcat.com/blog/2021/10/10/aspnetcore-options-pattern/" target="_blank">.NET Core</a>
+- <a href="https://configcat.com/blog/2021/10/10/aspnetcore-options-pattern/" target="_blank">ASP.NET Core</a>
 
 ## Look under the hood
 

--- a/website/docs/sdk-reference/openfeature/dotnet.mdx
+++ b/website/docs/sdk-reference/openfeature/dotnet.mdx
@@ -38,21 +38,23 @@ dotnet add package OpenFeature.Contrib.Providers.ConfigCat
 </Tabs>
 ### 2. Initialize the provider
 
-The `ConfigCatProvider` constructor takes the SDK key and an optional `ConfigCatClientOptions` argument containing the additional configuration options for the [ConfigCat .NET SDK](../../dotnet/#creating-the-configcat-client):
+The `ConfigCatProvider` constructor takes the SDK key and an optional callback that can be used to specify additional configuration options for the [ConfigCat .NET SDK](../../dotnet/#creating-the-configcat-client):
 
 ```cs
-using OpenFeature.Contrib.Providers.ConfigCat;
+using System;
+using ConfigCat.Client;
+using OpenFeature.Contrib.ConfigCat;
 
-// Build options for the ConfigCat SDK.
-var options = new ConfigCatClientOptions
+// Specify options for the ConfigCat SDK.
+Action<ConfigCat.Client.Configuration.ConfigCatClientOptions> configureOptions = (options) =>
 {
-    PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(60));
-    Logger = new ConsoleLogger(LogLevel.Warning);
+    options.PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(60));
+    options.Logger = new ConsoleLogger(LogLevel.Warning);
     // ...
 };
 
 // Configure the provider.
-OpenFeature.Api.Instance.SetProvider(new ConfigCatProvider("#YOUR-SDK-KEY#", options));
+await OpenFeature.Api.Instance.SetProviderAsync(new ConfigCatProvider("#YOUR-SDK-KEY#", configureOptions));
 
 // Create a client.
 var client = OpenFeature.Api.Instance.GetClient();
@@ -64,7 +66,7 @@ For more information about all the configuration options, see the [.NET SDK docu
 
 ```cs
 var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false);
-if(isAwesomeFeatureEnabled)
+if (isAwesomeFeatureEnabled)
 {
     doTheNewThing();
 }
@@ -72,6 +74,14 @@ else
 {
     doTheOldThing();
 }
+```
+
+### 4. Cleaning up
+
+On application shutdown, clean up the OpenFeature provider and the underlying ConfigCat client.
+
+```cs
+await OpenFeature.Api.Instance.ShutdownAsync();
 ```
 
 ## Evaluation Context
@@ -91,12 +101,12 @@ The following table shows how the different context attributes are mapped to Use
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
 ```cs
-var context = new EvaluationContext()
+var context = OpenFeature.Model.EvaluationContext.Builder()
     .Set("Id", "#SOME-USER-ID#")
     .Set("Email", "configcat@example.com")
     .Set("Country", "CountryID")
     .Set("Rating", 4.5)
-    .Set("RegisteredAt", DateTime.Parse("2023-11-22 12:34:56 +00:00", CultureInfo.InvariantCulture))
+    .Set("RegisteredAt", DateTime.Parse("2023-11-22 12:34:56 +00:00", System.Globalization.CultureInfo.InvariantCulture))
     .Build();
 
 var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false, context);

--- a/website/docs/sdk-reference/openfeature/js.mdx
+++ b/website/docs/sdk-reference/openfeature/js.mdx
@@ -53,6 +53,14 @@ if (isAwesomeFeatureEnabled) {
 }
 ```
 
+### 4. Cleaning up
+
+On application shutdown, clean up the OpenFeature provider and the underlying ConfigCat client.
+
+```cs
+await OpenFeature.clearProviders();
+```
+
 ## Evaluation Context
 
 An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.

--- a/website/docs/sdk-reference/openfeature/js.mdx
+++ b/website/docs/sdk-reference/openfeature/js.mdx
@@ -13,41 +13,29 @@ import TabItem from '@theme/TabItem';
 
 ### 1. Install the provider
 
-<Tabs groupId="js-install">
-<TabItem value="NPM" label="NPM">
-
 ```bash
 npm i @openfeature/config-cat-web-provider
 ```
 
-</TabItem>
-<TabItem value="CDN" label="CDN">
-
-```html
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js">
-</script>
-```
-
-</TabItem>
-</Tabs>
 ### 2. Initialize the provider
 
 The `ConfigCatWebProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat JavaScript SDK](../../js/#creating-the-configcat-client):
 
 ```js
+import { OpenFeature } from "@openfeature/web-sdk";
 import { ConfigCatWebProvider } from '@openfeature/config-cat-web-provider';
+import { createConsoleLogger, LogLevel } from "configcat-js-ssr";
 
 // Build options for the ConfigCat SDK.
-const options = { 
-    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
-    // ...
+const options = {
+  logger: createConsoleLogger(LogLevel.Info),
+  setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+  // ...
 }
 
 // Configure the provider.
-OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', options));
- 
+await OpenFeature.setProviderAndWait(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', options));
+
 // Create a client.
 const client = OpenFeature.getClient();
 ```
@@ -58,10 +46,10 @@ For more information about all the configuration options, see the [JavaScript SD
 
 ```js
 const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);
-if(isAwesomeFeatureEnabled) {
-    doTheNewThing();
+if (isAwesomeFeatureEnabled) {
+  doTheNewThing();
 } else {
-    doTheOldThing();
+  doTheOldThing();
 }
 ```
 
@@ -82,10 +70,10 @@ The following table shows how the different context attributes are mapped to Use
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
 ```js
-await OpenFeature.setContext({ 
-    targetingKey: '#SOME-USER-ID#', 
-    email: 'configcat@example.com', 
-    country: 'CountryID',
+await OpenFeature.setContext({
+  targetingKey: '#SOME-USER-ID#',
+  email: 'configcat@example.com',
+  country: 'CountryID',
 });
 
 const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);

--- a/website/docs/sdk-reference/openfeature/node.mdx
+++ b/website/docs/sdk-reference/openfeature/node.mdx
@@ -1,7 +1,7 @@
 ---
 id: node
 title: OpenFeature Provider for Node.js
-description: ConfigCat OpenFeature Provider for Node. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Node.js SDK.
+description: ConfigCat OpenFeature Provider for Node.js. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Node.js SDK.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -22,17 +22,20 @@ npm i @openfeature/config-cat-provider
 The `ConfigCatProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat Node.js SDK](../../node/#creating-the-configcat-client):
 
 ```js
+import { OpenFeature } from "@openfeature/server-sdk";
 import { ConfigCatProvider } from '@openfeature/config-cat-provider';
+import { createConsoleLogger, LogLevel, PollingMode } from "configcat-node";
 
 // Build options for the ConfigCat SDK.
-const options = { 
-    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
-    // ...
+const options = {
+  logger: createConsoleLogger(LogLevel.Info),
+  setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+  // ...
 }
 
 // Configure the provider.
-OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', PollingMode.AutoPoll, options));
- 
+await OpenFeature.setProviderAndWait(ConfigCatProvider.create('#YOUR-SDK-KEY#', PollingMode.AutoPoll, options));
+
 // Create a client.
 const client = OpenFeature.getClient();
 ```
@@ -43,11 +46,19 @@ For more information about all the configuration options, see the [Node.js SDK d
 
 ```js
 const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false);
-if(isAwesomeFeatureEnabled) {
-    doTheNewThing();
+if (isAwesomeFeatureEnabled) {
+  doTheNewThing();
 } else {
-    doTheOldThing();
+  doTheOldThing();
 }
+```
+
+### 4. Cleaning up
+
+On application shutdown, clean up the OpenFeature provider and the underlying ConfigCat client.
+
+```cs
+await OpenFeature.clearProviders();
 ```
 
 ## Evaluation Context
@@ -67,10 +78,10 @@ The following table shows how the different context attributes are mapped to Use
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
 ```js
-const context = { 
-    targetingKey: '#SOME-USER-ID#', 
-    email: 'configcat@example.com', 
-    country: 'CountryID',
+const context = {
+  targetingKey: '#SOME-USER-ID#',
+  email: 'configcat@example.com',
+  country: 'CountryID',
 };
 
 const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false, context);

--- a/website/docs/sdk-reference/overview.mdx
+++ b/website/docs/sdk-reference/overview.mdx
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: ConfigCat SDK Overview
-description: List of all supported technologies like .NET, .NET Core, Java, JavaScript, PHP, Python, Ruby, Go, Node.js, Android, Swift, iOS, Elixir, Dart, React, Angular, Vue.js, React, Chromium, Deno, Kotlin Multiplatform, Laravel, Server-Side Rendered apps, etc.
+description: List of all supported technologies like .NET, Java, JavaScript, PHP, Python, Ruby, Go, Node.js, Android, Swift, iOS, Elixir, Dart, React, Angular, Vue.js, React, Chromium, Deno, Kotlin Multiplatform, Laravel, Server-Side Rendered apps, etc.
 ---
 
 The purpose of the SDKs is to download and cache feature flag values and to evaluate Targeting Rules. All SDKs provide a simple interface for accessing your feature flags from your application.

--- a/website/versioned_docs/version-V1/sdk-reference/dotnet.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/dotnet.mdx
@@ -1,7 +1,7 @@
 ---
 id: dotnet
-title: .NET, .NET Core SDK Reference
-description: ConfigCat .NET, .NET Core SDK Reference. This is a step-by-step guide on how to use feature flags in your .NET, .NET Core application.
+title: .NET SDK Reference
+description: ConfigCat .NET SDK Reference. This is a step-by-step guide on how to use feature flags in your .NET application.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -776,7 +776,7 @@ Check out our Sample Applications how they use the _ConfigCat SDK_:
 See the following guides on how to use ConfigCat's .NET SDK:
 
 - <a href="https://configcat.com/blog/2022/11/25/feature-flags-in-net6/" target="_blank">.NET 6</a>
-- <a href="https://configcat.com/blog/2021/10/10/aspnetcore-options-pattern/" target="_blank">.NET Core</a>
+- <a href="https://configcat.com/blog/2021/10/10/aspnetcore-options-pattern/" target="_blank">ASP.NET Core</a>
 
 ## Look under the hood
 

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/dotnet.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/dotnet.mdx
@@ -38,21 +38,23 @@ dotnet add package OpenFeature.Contrib.Providers.ConfigCat
 </Tabs>
 ### 2. Initialize the provider
 
-The `ConfigCatProvider` constructor takes the SDK key and an optional `ConfigCatClientOptions` argument containing the additional configuration options for the [ConfigCat .NET SDK](../../dotnet/#creating-the-configcat-client):
+The `ConfigCatProvider` constructor takes the SDK key and an optional callback that can be used to specify additional configuration options for the [ConfigCat .NET SDK](../../dotnet/#creating-the-configcat-client):
 
 ```cs
-using OpenFeature.Contrib.Providers.ConfigCat;
+using System;
+using ConfigCat.Client;
+using OpenFeature.Contrib.ConfigCat;
 
-// Build options for the ConfigCat SDK.
-var options = new ConfigCatClientOptions
+// Specify options for the ConfigCat SDK.
+Action<ConfigCat.Client.Configuration.ConfigCatClientOptions> configureOptions = (options) =>
 {
-    PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(60));
-    Logger = new ConsoleLogger(LogLevel.Warning);
+    options.PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(60));
+    options.Logger = new ConsoleLogger(LogLevel.Warning);
     // ...
 };
 
 // Configure the provider.
-OpenFeature.Api.Instance.SetProvider(new ConfigCatProvider("#YOUR-SDK-KEY#", options));
+await OpenFeature.Api.Instance.SetProviderAsync(new ConfigCatProvider("#YOUR-SDK-KEY#", configureOptions));
 
 // Create a client.
 var client = OpenFeature.Api.Instance.GetClient();
@@ -64,7 +66,7 @@ For more information about all the configuration options, see the [.NET SDK docu
 
 ```cs
 var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false);
-if(isAwesomeFeatureEnabled)
+if (isAwesomeFeatureEnabled)
 {
     doTheNewThing();
 }
@@ -72,6 +74,14 @@ else
 {
     doTheOldThing();
 }
+```
+
+### 4. Cleaning up
+
+On application shutdown, clean up the OpenFeature provider and the underlying ConfigCat client.
+
+```cs
+await OpenFeature.Api.Instance.ShutdownAsync();
 ```
 
 ## Evaluation Context
@@ -91,12 +101,12 @@ The following table shows how the different context attributes are mapped to Use
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
 ```cs
-var context = new EvaluationContext()
+var context = OpenFeature.Model.EvaluationContext.Builder()
     .Set("Id", "#SOME-USER-ID#")
     .Set("Email", "configcat@example.com")
     .Set("Country", "CountryID")
     .Set("Rating", 4.5)
-    .Set("RegisteredAt", DateTime.Parse("2023-11-22 12:34:56 +00:00", CultureInfo.InvariantCulture))
+    .Set("RegisteredAt", DateTime.Parse("2023-11-22 12:34:56 +00:00", System.Globalization.CultureInfo.InvariantCulture))
     .Build();
 
 var isAwesomeFeatureEnabled = await client.GetBooleanValueAsync("isAwesomeFeatureEnabled", false, context);

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
@@ -53,6 +53,14 @@ if (isAwesomeFeatureEnabled) {
 }
 ```
 
+### 4. Cleaning up
+
+On application shutdown, clean up the OpenFeature provider and the underlying ConfigCat client.
+
+```cs
+await OpenFeature.clearProviders();
+```
+
 ## Evaluation Context
 
 An <a href="https://openfeature.dev/docs/reference/concepts/evaluation-context" target="_blank">evaluation context</a> in the OpenFeature specification is a container for arbitrary contextual data that can be used as a basis for feature flag evaluation.

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/js.mdx
@@ -13,41 +13,29 @@ import TabItem from '@theme/TabItem';
 
 ### 1. Install the provider
 
-<Tabs groupId="js-install">
-<TabItem value="NPM" label="NPM">
-
 ```bash
 npm i @openfeature/config-cat-web-provider
 ```
 
-</TabItem>
-<TabItem value="CDN" label="CDN">
-
-```html
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/@openfeature/config-cat-web-provider/index.cjs.min.js">
-</script>
-```
-
-</TabItem>
-</Tabs>
 ### 2. Initialize the provider
 
 The `ConfigCatWebProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat JavaScript SDK](../../js/#creating-the-configcat-client):
 
 ```js
+import { OpenFeature } from "@openfeature/web-sdk";
 import { ConfigCatWebProvider } from '@openfeature/config-cat-web-provider';
+import { createConsoleLogger, LogLevel } from "configcat-js-ssr";
 
 // Build options for the ConfigCat SDK.
-const options = { 
-    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
-    // ...
+const options = {
+  logger: createConsoleLogger(LogLevel.Info),
+  setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+  // ...
 }
 
 // Configure the provider.
-OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', options));
- 
+await OpenFeature.setProviderAndWait(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', options));
+
 // Create a client.
 const client = OpenFeature.getClient();
 ```
@@ -58,10 +46,10 @@ For more information about all the configuration options, see the [JavaScript SD
 
 ```js
 const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);
-if(isAwesomeFeatureEnabled) {
-    doTheNewThing();
+if (isAwesomeFeatureEnabled) {
+  doTheNewThing();
 } else {
-    doTheOldThing();
+  doTheOldThing();
 }
 ```
 
@@ -82,10 +70,10 @@ The following table shows how the different context attributes are mapped to Use
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
 ```js
-await OpenFeature.setContext({ 
-    targetingKey: '#SOME-USER-ID#', 
-    email: 'configcat@example.com', 
-    country: 'CountryID',
+await OpenFeature.setContext({
+  targetingKey: '#SOME-USER-ID#',
+  email: 'configcat@example.com',
+  country: 'CountryID',
 });
 
 const isAwesomeFeatureEnabled = client.getBooleanValue('isAwesomeFeatureEnabled', false);

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/node.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/node.mdx
@@ -1,7 +1,7 @@
 ---
 id: node
 title: OpenFeature Provider for Node.js
-description: ConfigCat OpenFeature Provider for Node. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Node.js SDK.
+description: ConfigCat OpenFeature Provider for Node.js. This is a step-by-step guide on how to use ConfigCat with the OpenFeature Node.js SDK.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -22,17 +22,20 @@ npm i @openfeature/config-cat-provider
 The `ConfigCatProvider.create()` function takes the SDK key and an optional `options` argument containing additional configuration options for the [ConfigCat Node.js SDK](../../node/#creating-the-configcat-client):
 
 ```js
+import { OpenFeature } from "@openfeature/server-sdk";
 import { ConfigCatProvider } from '@openfeature/config-cat-provider';
+import { createConsoleLogger, LogLevel, PollingMode } from "configcat-node";
 
 // Build options for the ConfigCat SDK.
-const options = { 
-    setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
-    // ...
+const options = {
+  logger: createConsoleLogger(LogLevel.Info),
+  setupHooks: (hooks) => hooks.on('clientReady', () => console.log('Client is ready!')),
+  // ...
 }
 
 // Configure the provider.
-OpenFeature.setProvider(ConfigCatWebProvider.create('#YOUR-SDK-KEY#', PollingMode.AutoPoll, options));
- 
+await OpenFeature.setProviderAndWait(ConfigCatProvider.create('#YOUR-SDK-KEY#', PollingMode.AutoPoll, options));
+
 // Create a client.
 const client = OpenFeature.getClient();
 ```
@@ -43,11 +46,19 @@ For more information about all the configuration options, see the [Node.js SDK d
 
 ```js
 const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false);
-if(isAwesomeFeatureEnabled) {
-    doTheNewThing();
+if (isAwesomeFeatureEnabled) {
+  doTheNewThing();
 } else {
-    doTheOldThing();
+  doTheOldThing();
 }
+```
+
+### 4. Cleaning up
+
+On application shutdown, clean up the OpenFeature provider and the underlying ConfigCat client.
+
+```cs
+await OpenFeature.clearProviders();
 ```
 
 ## Evaluation Context
@@ -67,10 +78,10 @@ The following table shows how the different context attributes are mapped to Use
 To evaluate feature flags for a context, use the <a href="https://openfeature.dev/docs/reference/concepts/evaluation-api/" target="_blank">OpenFeature Evaluation API</a>:
 
 ```js
-const context = { 
-    targetingKey: '#SOME-USER-ID#', 
-    email: 'configcat@example.com', 
-    country: 'CountryID',
+const context = {
+  targetingKey: '#SOME-USER-ID#',
+  email: 'configcat@example.com',
+  country: 'CountryID',
 };
 
 const isAwesomeFeatureEnabled = await client.getBooleanValue('isAwesomeFeatureEnabled', false, context);

--- a/website/versioned_docs/version-V1/sdk-reference/overview.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/overview.mdx
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: ConfigCat SDK Overview
-description: List of all supported technologies like .NET, .NET Core, Java, JavaScript, PHP, Python, Ruby, Go, Node.js, Android, Swift, iOS, Elixir, Dart, React, Angular, Vue.js, React, Chromium, Deno, Kotlin Multiplatform, Laravel, Server-Side Rendered apps, etc.
+description: List of all supported technologies like .NET, Java, JavaScript, PHP, Python, Ruby, Go, Node.js, Android, Swift, iOS, Elixir, Dart, React, Angular, Vue.js, React, Chromium, Deno, Kotlin Multiplatform, Laravel, Server-Side Rendered apps, etc.
 ---
 
 The purpose of the SDKs is to download and cache feature flag values and to evaluate Targeting Rules. All SDKs provide a simple interface for accessing your feature flags from your application.


### PR DESCRIPTION
### Description

This PR fixes a bunch of major and minor errors in the code samples in the docs of OpenFeature providers mentioned in the title. (It's worth mentioning in particular that currently the OF provider for web package doesn't include a bundle that can be referenced directly, via a `<script>` tag in browsers. This is something that should be addressed at OF's side. Here I just removed that part from the docs for now.)

Also, gets rid of mentions of .NET Core as it is obsolete now.

### Trello card

n/a

### Notes for QA

Ideally, the new code samples should be verified by executing them.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
