### PR TITLE
Small typo fixes and js-ssr lambda block restructure

### DIFF
--- a/website/docs/advanced/code-references/overview.mdx
+++ b/website/docs/advanced/code-references/overview.mdx
@@ -104,7 +104,7 @@ public static class FeatureFlagKeys
 The scanner will treat this constant's usage as an indirect reference to the flag.
 
 ```csharp
-if (configCatClient.GetValue(FeatureFlagKeys.MyAwesomeFeature, false))
+if (await configCatClient.GetValueAsync(FeatureFlagKeys.MyAwesomeFeature, false))
 {
   // the feature is on.
 }

--- a/website/docs/advanced/code-references/overview.mdx
+++ b/website/docs/advanced/code-references/overview.mdx
@@ -97,7 +97,7 @@ For example, the following `C#` constant's name (`MyAwesomeFeature`) will be rec
 ```csharp
 public static class FeatureFlagKeys
 {
-  public const string MyAwesomeFeature = "my_awesome_feature";
+    public const string MyAwesomeFeature = "my_awesome_feature";
 }
 ```
 
@@ -106,7 +106,7 @@ The scanner will treat this constant's usage as an indirect reference to the fla
 ```csharp
 if (await configCatClient.GetValueAsync(FeatureFlagKeys.MyAwesomeFeature, false))
 {
-  // the feature is on.
+    // the feature is on.
 }
 ```
 

--- a/website/docs/advanced/code-references/overview.mdx
+++ b/website/docs/advanced/code-references/overview.mdx
@@ -72,7 +72,7 @@ export CONFIGCAT_USAGE_PATTERNS="<pattern1>,<pattern2>";
 ```
 
 The regex pattern must include the `CC_KEY` placeholder that represents the actual feature flag or setting key in your code.
-For example, the following pattern allows the recognition of Ruby symbols as flag key usage:
+For example, the following pattern allows the recognition of Ruby symbols as flag key usages:
 
 ```bash
 configcat scan <dir> --usage-patterns ":CC_KEY"
@@ -85,7 +85,6 @@ if FeatureFlags.enabled(:my_feature_key)
   #...
 end
 ```
-
 :::
 
 ### Aliases
@@ -150,7 +149,7 @@ There's an option to set custom regex patterns for identifying additional aliase
 configcat scan <dir> --alias-patterns "<pattern1>" "<pattern2>"
 ```
 
-The CLI expects the patterns from `CONFIGCAT_ALIAS_PATTERNS` as a comma delimited list.
+The CLI also accepts patterns from the `CONFIGCAT_ALIAS_PATTERNS` environment variable as a comma delimited list.
 
 ```bash
 export CONFIGCAT_ALIAS_PATTERNS="<pattern1>,<pattern2>";
@@ -158,7 +157,7 @@ export CONFIGCAT_ALIAS_PATTERNS="<pattern1>,<pattern2>";
 
 #### Match pattern format
 
-The regex pattern must include at least one capture group that represents the actual alias. When more then one group is defined, the first one is selected.
+The regex pattern must include at least one capture group that represents the actual alias. When more than one group is defined, the first one is selected.
 To bind the actual flag keys to aliases, the CLI uses a `CC_KEY` placeholder to inject the known keys into the pattern.
 
 For example, the following pattern allows to find aliases that point to Ruby symbols:
@@ -189,17 +188,17 @@ For example, the scanner will treat the `IsMyAwesomeFeatureEnabled` function of 
 ```csharp
 public class FeatureFlagProvider
 {
-  public bool IsMyAwesomeFeatureEnabled(bool defaultValue = false)
+  public async Task<bool> IsMyAwesomeFeatureEnabled(bool defaultValue = false)
   {
-    return configCatClient.GetValue("my_awesome_feature", defaultValue);
+    return await configCatClient.GetValueAsync("my_awesome_feature", defaultValue);
   }
 }
 ```
 
-And will include it's usage in the scan report:
+And will include its usage in the scan report:
 
 ```csharp
-if (featureFlagProvider.IsMyAwesomeFeatureEnabled())
+if (await featureFlagProvider.IsMyAwesomeFeatureEnabled())
 {
   // the feature is on.
 }

--- a/website/docs/sdk-reference/js-ssr.mdx
+++ b/website/docs/sdk-reference/js-ssr.mdx
@@ -818,8 +818,11 @@ You can view a sample run [here](https://github.com/configcat/js-ssr-sdk/actions
 ## Next.js/AWS lambda recommendation
 
 If the SDK is running in a Next.js application that is hosted on Vercel (AWS lambda) or your application is hosted directly in AWS lambdas, it is recommended to use the SDK in Lazy loading or Manual polling mode instead of the default Auto polling mode.
+
 As AWS lamdbas try to minimize their uptime, the applications are terminated as soon as the sytem detects inactivity in the application. 
+
 The Auto polling mode is using a background thread to acquire the setting values from the ConfigCat servers periodically and the AWS lambda does not detect it as a running application and terminates it. 
+
 However, it can easily happen that there is an ongoing HTTP GET call towards our servers and this termination can cause errors.
 The most possible error message in this case is `Request timed out while trying to fetch config JSON.`.
 

--- a/website/docs/sdk-reference/openfeature/go.mdx
+++ b/website/docs/sdk-reference/openfeature/go.mdx
@@ -35,7 +35,7 @@ configcatClient := sdk.NewCustomClient(sdk.Config{SDKKey: "#YOUR-SDK-KEY#",
 // Configure the provider.
 openfeature.SetProvider(configcat.NewProvider(configcatClient))
 
-# Create a client.
+// Create a client.
 client := openfeature.NewClient("app")
 ```
 

--- a/website/docs/sdk-reference/openfeature/java.mdx
+++ b/website/docs/sdk-reference/openfeature/java.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 ```groovy title="build.gradle"
 dependencies {
-    implementation 'dev.openfeature.contrib.providers:configcat:0.0.4'
+    implementation 'dev.openfeature.contrib.providers:configcat:0.1.+'
     implementation 'dev.openfeature:sdk:1.+'
 }
 ```
@@ -30,7 +30,7 @@ dependencies {
 <dependency>
     <groupId>dev.openfeature.contrib.providers</groupId>
     <artifactId>configcat</artifactId>
-    <version>0.0.4</version>
+    <version>[0.1,)</version>
 </dependency>
 <dependency>
     <groupId>dev.openfeature</groupId>

--- a/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
@@ -104,7 +104,7 @@ public static class FeatureFlagKeys
 The scanner will treat this constant's usage as an indirect reference to the flag.
 
 ```csharp
-if (configCatClient.GetValue(FeatureFlagKeys.MyAwesomeFeature, false))
+if (await configCatClient.GetValueAsync(FeatureFlagKeys.MyAwesomeFeature, false))
 {
   // the feature is on.
 }

--- a/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
@@ -72,7 +72,7 @@ export CONFIGCAT_USAGE_PATTERNS="<pattern1>,<pattern2>";
 ```
 
 The regex pattern must include the `CC_KEY` placeholder that represents the actual feature flag or setting key in your code.
-For example, the following pattern allows the recognition of Ruby symbols as flag key usage:
+For example, the following pattern allows the recognition of Ruby symbols as flag key usages:
 
 ```bash
 configcat scan <dir> --usage-patterns ":CC_KEY"
@@ -143,13 +143,13 @@ This behavior prevents false recognitions in expressions like `<input type="text
 
 ### Custom alias match patterns
 
-There's an option to set custom regex patterns for identifying additional aliases. The `scan` command accepts a list of patterns via the `--alias-patterns` argument or via the `CONFIGCAT_ALIAS_PATTERNS` environment variable.
+There's an option to set custom regex patterns for identifying additional aliases. The `scan` command accepts a list of patterns via the `--alias-patterns` argument.
 
 ```bash
 configcat scan <dir> --alias-patterns "<pattern1>" "<pattern2>"
 ```
 
-The CLI expects the patterns from `CONFIGCAT_ALIAS_PATTERNS` as a comma delimited list.
+The CLI also accepts patterns from the `CONFIGCAT_ALIAS_PATTERNS` environment variable as a comma delimited list.
 
 ```bash
 export CONFIGCAT_ALIAS_PATTERNS="<pattern1>,<pattern2>";
@@ -157,7 +157,7 @@ export CONFIGCAT_ALIAS_PATTERNS="<pattern1>,<pattern2>";
 
 #### Match pattern format
 
-The regex pattern must include at least one capture group that represents the actual alias. When more then one group is defined, the first one is selected.
+The regex pattern must include at least one capture group that represents the actual alias. When more than one group is defined, the first one is selected.
 To bind the actual flag keys to aliases, the CLI uses a `CC_KEY` placeholder to inject the known keys into the pattern.
 
 For example, the following pattern allows to find aliases that point to Ruby symbols:
@@ -188,17 +188,17 @@ For example, the scanner will treat the `IsMyAwesomeFeatureEnabled` function of 
 ```csharp
 public class FeatureFlagProvider
 {
-  public bool IsMyAwesomeFeatureEnabled(bool defaultValue = false)
+  public async Task<bool> IsMyAwesomeFeatureEnabled(bool defaultValue = false)
   {
-    return configCatClient.GetValue("my_awesome_feature", defaultValue);
+    return await configCatClient.GetValueAsync("my_awesome_feature", defaultValue);
   }
 }
 ```
 
-And will include it's usage in the scan report:
+And will include its usage in the scan report:
 
 ```csharp
-if (featureFlagProvider.IsMyAwesomeFeatureEnabled())
+if (await featureFlagProvider.IsMyAwesomeFeatureEnabled())
 {
   // the feature is on.
 }

--- a/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
+++ b/website/versioned_docs/version-V1/advanced/code-references/overview.mdx
@@ -97,7 +97,7 @@ For example, the following `C#` constant's name (`MyAwesomeFeature`) will be rec
 ```csharp
 public static class FeatureFlagKeys
 {
-  public const string MyAwesomeFeature = "my_awesome_feature";
+    public const string MyAwesomeFeature = "my_awesome_feature";
 }
 ```
 
@@ -106,7 +106,7 @@ The scanner will treat this constant's usage as an indirect reference to the fla
 ```csharp
 if (await configCatClient.GetValueAsync(FeatureFlagKeys.MyAwesomeFeature, false))
 {
-  // the feature is on.
+    // the feature is on.
 }
 ```
 

--- a/website/versioned_docs/version-V1/sdk-reference/js-ssr.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/js-ssr.mdx
@@ -779,8 +779,11 @@ You can view a sample run [here](https://github.com/configcat/js-ssr-sdk/actions
 ## Next.js/AWS lambda recommendation
 
 If the SDK is running in a Next.js application that is hosted on Vercel (AWS lambda) or your application is hosted directly in AWS lambdas, it is recommended to use the SDK in Lazy loading or Manual polling mode instead of the default Auto polling mode.
+
 As AWS lamdbas try to minimize their uptime, the applications are terminated as soon as the sytem detects inactivity in the application. 
+
 The Auto polling mode is using a background thread to acquire the setting values from the ConfigCat servers periodically and the AWS lambda does not detect it as a running application and terminates it. 
+
 However, it can easily happen that there is an ongoing HTTP GET call towards our servers and this termination can cause errors.
 The most possible error message in this case is `Request timed out while trying to fetch config JSON.`.
 

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
@@ -35,7 +35,7 @@ configcatClient := sdk.NewCustomClient(sdk.Config{SDKKey: "#YOUR-SDK-KEY#",
 // Configure the provider.
 openfeature.SetProvider(configcat.NewProvider(configcatClient))
 
-# Create a client.
+// Create a client.
 client := openfeature.NewClient("app")
 ```
 

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/java.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/java.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 ```groovy title="build.gradle"
 dependencies {
-    implementation 'dev.openfeature.contrib.providers:configcat:0.0.4'
+    implementation 'dev.openfeature.contrib.providers:configcat:0.1.+'
     implementation 'dev.openfeature:sdk:1.+'
 }
 ```
@@ -30,7 +30,7 @@ dependencies {
 <dependency>
     <groupId>dev.openfeature.contrib.providers</groupId>
     <artifactId>configcat</artifactId>
-    <version>0.0.4</version>
+    <version>[0.1,)</version>
 </dependency>
 <dependency>
     <groupId>dev.openfeature</groupId>


### PR DESCRIPTION
### Description

Small typo fixes in the code references docs and js-ssr lambda block restructure.

Before:
![image](https://github.com/user-attachments/assets/bf990242-724c-4c12-b062-f11654f5b23b)

After:
![image](https://github.com/user-attachments/assets/0ac3a8dc-0671-41d9-b38d-31c8763dbfd6)

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
