### PR TITLE
Add Rust SDK to Proxy supported SDKs / fix 'eval-all' sample request

### DIFF
--- a/website/docs/advanced/proxy/endpoints.mdx
+++ b/website/docs/advanced/proxy/endpoints.mdx
@@ -75,7 +75,7 @@ import * as configcat from "configcat-js";
 
 var configCatClient = configcat.getClient(
   // highlight-next-line
-  "configcat-proxy/my_sdk", // SDK identifier as SDK key
+  "configcat-proxy/my_sdk", // SDK identifier as SDK key prefixed with 'configcat-proxy/'
   configcat.PollingMode.AutoPoll,
   // highlight-next-line
   { baseUrl: "http(s)://localhost:8050" } // Proxy URL
@@ -105,6 +105,7 @@ The following SDK versions are supported by the `>=v0.3.X` Proxy's CDN endpoint:
 | PHP 7.1+ | [`>=v3.0.0`](https://github.com/configcat/php7-sdk/releases/tag/v3.0.0)     |
 | Ruby    | [`>=v8.0.0`](https://github.com/configcat/ruby-sdk/releases/tag/v8.0.0)      |
 | Swift   | [`>=v11.0.0`](https://github.com/configcat/swift-sdk/releases/tag/11.0.0)    |
+| Rust    | [`>=v0.1.0`](https://github.com/configcat/rust-sdk/releases/tag/v0.1.0)      |
 
 </TabItem>
 <TabItem value="old" label="Proxy version 0.2.X or older">
@@ -188,7 +189,7 @@ The following SDK versions are supported by the `<=v0.2.X` Proxy's CDN endpoint:
 | Kotlin  | [`<=2.0.0`](https://github.com/configcat/kotlin-sdk/releases/tag/2.0.0)    |
 | PHP     | [`<=v8.1.0`](https://github.com/configcat/php-sdk/releases/tag/v8.1.0)     |
 | Ruby    | [`<=v7.0.0`](https://github.com/configcat/ruby-sdk/releases/tag/v7.0.0)    |
-| Swift   | [`<=v10.0.0`](https://github.com/configcat/swift-sdk/releases/tag/10.0.0) |
+| Swift   | [`<=v10.0.0`](https://github.com/configcat/swift-sdk/releases/tag/10.0.0)  |
 
 </TabItem>
 </Tabs>
@@ -438,7 +439,6 @@ This endpoint evaluates all feature flags with the given [User Object](../../tar
 **Request body**:
 ```json
 {
-  "key": "<feature-flag-key>",
   "user": {
     "Identifier": "<user-id>",
     "Rating": 4.5,

--- a/website/versioned_docs/version-V1/advanced/proxy/endpoints.mdx
+++ b/website/versioned_docs/version-V1/advanced/proxy/endpoints.mdx
@@ -75,7 +75,7 @@ import * as configcat from "configcat-js";
 
 var configCatClient = configcat.getClient(
   // highlight-next-line
-  "configcat-proxy/my_sdk", // SDK identifier as SDK key
+  "configcat-proxy/my_sdk", // SDK identifier as SDK key prefixed with 'configcat-proxy/'
   configcat.PollingMode.AutoPoll,
   // highlight-next-line
   { baseUrl: "http(s)://localhost:8050" } // Proxy URL
@@ -105,6 +105,7 @@ The following SDK versions are supported by the `>=v0.3.X` Proxy's CDN endpoint:
 | PHP 7.1+ | [`>=v3.0.0`](https://github.com/configcat/php7-sdk/releases/tag/v3.0.0)     |
 | Ruby    | [`>=v8.0.0`](https://github.com/configcat/ruby-sdk/releases/tag/v8.0.0)      |
 | Swift   | [`>=v11.0.0`](https://github.com/configcat/swift-sdk/releases/tag/11.0.0)    |
+| Rust    | [`>=v0.1.0`](https://github.com/configcat/rust-sdk/releases/tag/v0.1.0)      |
 
 </TabItem>
 <TabItem value="old" label="Proxy version 0.2.X or older">
@@ -188,7 +189,7 @@ The following SDK versions are supported by the `<=v0.2.X` Proxy's CDN endpoint:
 | Kotlin  | [`<=2.0.0`](https://github.com/configcat/kotlin-sdk/releases/tag/2.0.0)    |
 | PHP     | [`<=v8.1.0`](https://github.com/configcat/php-sdk/releases/tag/v8.1.0)     |
 | Ruby    | [`<=v7.0.0`](https://github.com/configcat/ruby-sdk/releases/tag/v7.0.0)    |
-| Swift   | [`<=v10.0.0`](https://github.com/configcat/swift-sdk/releases/tag/10.0.0) |
+| Swift   | [`<=v10.0.0`](https://github.com/configcat/swift-sdk/releases/tag/10.0.0)  |
 
 </TabItem>
 </Tabs>
@@ -438,7 +439,6 @@ This endpoint evaluates all feature flags with the given [User Object](../user-o
 **Request body**:
 ```json
 {
-  "key": "<feature-flag-key>",
   "user": {
     "Identifier": "<user-id>",
     "Rating": 4.5,


### PR DESCRIPTION
### Description

Add Rust SDK to Proxy supported SDKs / fix 'eval-all' sample request.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
