### PR TITLE
Update Kotlin SDK hooks onClientReady description.

### DIFF
--- a/website/docs/sdk-reference/kotlin.mdx
+++ b/website/docs/sdk-reference/kotlin.mdx
@@ -400,7 +400,7 @@ client.forceRefresh()
 
 With the following hooks you can subscribe to particular events fired by the SDK:
 
-- `onClientReady()`: This event is sent when the SDK reaches the ready state. If the SDK is initialized with lazy load or manual polling it's considered ready right after instantiation.
+- `onClientReady(ClientCacheState)`: This event is sent when the SDK reaches the ready state. If the SDK is set up to use lazy loading or manual polling, it's considered ready right after syncing up with the config cache.
   If it's using auto polling, the ready state is reached when the SDK has a valid config JSON loaded into memory either from cache or from HTTP. If the config couldn't be loaded neither from cache nor from HTTP the `onClientReady` event fires when the auto polling's `maxInitWaitTime` is reached.
 
 - `onConfigChanged(Map<String, Setting>)`: This event is sent when the SDK loads a valid config JSON into memory from cache, and each subsequent time when the loaded config JSON changes via HTTP.


### PR DESCRIPTION
### Description

Updated the Kotlin SDK onClientReady Hook description based on Kotlin SDK 4.1.0 changes.

### Trello card

[Trello ticket](https://trello.com/c/D6uM4Bxw/402-java-android-kotlin-sdk-rework-onclientready-hook-and-implement-waitforready)

### Notes for QA

Only the v2 docs changed.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
