### PR TITLE
API docs V2 only, no version dropdown

### DIFF
--- a/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import DocsVersionDropdownNavbarItem from '@theme-original/NavbarItem/DocsVersionDropdownNavbarItem';
+import type DocsVersionDropdownNavbarItemType from '@theme/NavbarItem/DocsVersionDropdownNavbarItem';
+import type { WrapperProps } from '@docusaurus/types';
+import { useLocation } from '@docusaurus/router';
+
+type Props = WrapperProps<typeof DocsVersionDropdownNavbarItemType>;
+
+export default function DocsVersionDropdownNavbarItemWrapper(props: Props): JSX.Element {
+  const location = useLocation();
+
+  const unversionedRoutes = [
+    // any route that starts with `/docs/api`
+    /^\/docs\/api\/.*$/g,
+    // If we want to disable it on the sdk reference too
+    // /^\/docs\/sdk-reference\/.*$/g
+  ]
+
+  function checkPathname(pathname) {
+    // Check if the provided pathname matches any of the regexes in the list
+    return unversionedRoutes.some(regex => regex.test(pathname))
+  }
+
+  if (checkPathname(location.pathname)) {
+    return null;
+  }
+
+  return <DocsVersionDropdownNavbarItem {...props} />;
+}


### PR DESCRIPTION
### Description

API docs V2 only, no version dropdown

### Trello card

https://trello.com/c/JQFxgM6k/1294-docs-n%C3%A1l-az-api-doksin%C3%A1l-ne-legyen-verzi%C3%B3-v%C3%A1laszt%C3%B3

### Notes for QA

What part of the application were affected by the changes? What should be tested?

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
