### PR TITLE
Remove mention of deprecated parameter

### DIFF
--- a/website/docs/sdk-reference/java.mdx
+++ b/website/docs/sdk-reference/java.mdx
@@ -399,8 +399,6 @@ ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options -> {
 });
 ```
 
-If you set the `asyncRefresh` to `false`, the refresh operation will be awaited until the downloading of the new configuration is completed.
-
 Available options:
 
 | Option Parameter                | Description | Default |

--- a/website/versioned_docs/version-V1/sdk-reference/java.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/java.mdx
@@ -360,8 +360,6 @@ ConfigCatClient client = ConfigCatClient.get("#YOUR-SDK-KEY#", options -> {
 });
 ```
 
-If you set the `asyncRefresh` to `false`, the refresh operation will be awaited until the downloading of the new configuration is completed.
-
 Available options:
 
 | Option Parameter                | Description | Default |


### PR DESCRIPTION
### Description

Remove mention of deprecated `asyncRefresh` parameter from Java docs.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
