### PR TITLE
Temporary go sdk version downgrade due to the latest provider is not released yet

### DIFF
--- a/website/docs/sdk-reference/openfeature/go.mdx
+++ b/website/docs/sdk-reference/openfeature/go.mdx
@@ -22,7 +22,7 @@ The ConfigCat Provider needs a pre-configured [ConfigCat Go SDK](../../go/#creat
 import (
     "context"
 
-    sdk "github.com/configcat/go-sdk/v9"
+    sdk "github.com/configcat/go-sdk/v8"
     configcat "github.com/open-feature/go-sdk-contrib/providers/configcat/pkg"
     "github.com/open-feature/go-sdk/openfeature"
 )

--- a/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/openfeature/go.mdx
@@ -22,7 +22,7 @@ The ConfigCat Provider needs a pre-configured [ConfigCat Go SDK](../../go/#creat
 import (
     "context"
 
-    sdk "github.com/configcat/go-sdk/v9"
+    sdk "github.com/configcat/go-sdk/v8"
     configcat "github.com/open-feature/go-sdk-contrib/providers/configcat/pkg"
     "github.com/open-feature/go-sdk/openfeature"
 )


### PR DESCRIPTION
### Description

Temporary go sdk version downgrade in the OpenFeature provider docs due to the latest provider is not released yet.

### Requirement checklist

- [x] I have validated my changes on a test/local environment.
- [x] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
- [ ] I have checked the SNYK/Dependabot reports and applied the suggested changes.
- [ ] (Optional) I have updated outdated packages.
