### PR TITLE
Prepare site for screenshots created according to the new guide

### DIFF
--- a/website/docs/news.mdx
+++ b/website/docs/news.mdx
@@ -167,8 +167,8 @@ We just released a new official ConfigCat SDK supporting Rust applications.
 We're happy to share that we have added the ability to connect multiple <a href="https://app.configcat.com/integrations" target="_blank" rel="noopener noreferrer">integrations</a> of the same type.<br/>
 Moreover, it's now possible to apply environment/config filters on each individual integration.
 
-<img src="/docs/assets/news/multi_integ_1.png" height="500" decoding="async" loading="lazy"/>
-<img src="/docs/assets/news/multi_integ_2.png" height="500" decoding="async" loading="lazy"/>
+<img src="/docs/assets/news/multi_integ_1.png" width="440" height="500" decoding="async" loading="lazy"/>
+<img src="/docs/assets/news/multi_integ_2.png" width="380" height="500" decoding="async" loading="lazy"/>
 
 
 ---

--- a/website/docs/targeting/targeting-rule/flag-condition.mdx
+++ b/website/docs/targeting/targeting-rule/flag-condition.mdx
@@ -28,11 +28,11 @@ You can set a Flag Condition for a feature flag on the ConfigCat Dashboard. The 
 
 #### Prerequisite is a feature flag (boolean setting)
 {/* ![Flag Condition anatomy 1](/assets/targeting/targeting-rule/flag-condition/flag-condition-anatomy1.png) */}
-<img src="/docs/assets/targeting/targeting-rule/flag-condition/flag-condition-anatomy1.png" height="50" alt="Flag Condition anatomy 1" decoding="async" loading="lazy"/>
+<img src="/docs/assets/targeting/targeting-rule/flag-condition/flag-condition-anatomy1.png" width="572" height="50" alt="Flag Condition anatomy 1" decoding="async" loading="lazy"/>
 
 #### Prerequisite is a string, integer or double setting
 {/* ![Flag Condition anatomy 2](/assets/targeting/targeting-rule/flag-condition/flag-condition-anatomy2.png) */}
-<img src="/docs/assets/targeting/targeting-rule/flag-condition/flag-condition-anatomy2.png" height="50" alt="Flag Condition anatomy 2" decoding="async" loading="lazy"/>
+<img src="/docs/assets/targeting/targeting-rule/flag-condition/flag-condition-anatomy2.png" width="958" height="50" alt="Flag Condition anatomy 2" decoding="async" loading="lazy"/>
 
 A Flag Condition consists of the following: 
 

--- a/website/docs/targeting/targeting-rule/segment-condition.mdx
+++ b/website/docs/targeting/targeting-rule/segment-condition.mdx
@@ -35,7 +35,7 @@ You can define your segments on the [ConfigCat Dashboard under the Segments tab]
 
 ## Anatomy of a Segment Condition
 
-<img src="/docs/assets/targeting/targeting-rule/segment-condition/segment-condition-anatomy.png" height="50" alt="Segment Condition anatomy" decoding="async" loading="lazy"/>
+<img src="/docs/assets/targeting/targeting-rule/segment-condition/segment-condition-anatomy.png" width="696" height="50" alt="Segment Condition anatomy" decoding="async" loading="lazy"/>
 
 A *Segment Condition* consists of two parts: 
 

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -81,3 +81,8 @@ span[class*='codeLineNumber'] {
   -ms-user-select: none; /* Internet Explorer/Edge */
   user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
+
+main article img:not(.no-auto-height) {
+  // See also https://github.com/configcat-labs/content-wiki/blob/main/screenshot-guide.md#embedding-screenshots
+  height: auto;
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -121,7 +121,7 @@ function Feature({ imageUrl, title, description, links }) {
     <div className={clsx('col col--3', styles.feature)}>
       {imgUrl && (
         <div className="text--center">
-          <img className={styles.featureImage} src={imgUrl} alt={title} />
+          <img className={clsx('no-auto-height', styles.featureImage)} src={imgUrl} alt={title} />
         </div>
       )}
       <h3>{title}</h3>
@@ -150,7 +150,7 @@ function Home() {
           <h1 className="hero__title">{siteConfig.title}</h1>
           <p className="hero__subtitle">{siteConfig.tagline}</p>
           <img
-            className={styles.heroImage}
+            className={clsx('no-auto-height', styles.heroImage)}
             src={useBaseUrl('img/docs.svg')}
             alt="ConfigCat Docs"
           />

--- a/website/versioned_docs/version-V1/news.mdx
+++ b/website/versioned_docs/version-V1/news.mdx
@@ -171,8 +171,8 @@ We just released a new official ConfigCat SDK supporting Rust applications.
 We're happy to share that we have added the ability to connect multiple <a href="https://app.configcat.com/integrations" target="_blank" rel="noopener noreferrer">integrations</a> of the same type.<br/>
 Moreover, it's now possible to apply environment/config filters on each individual integration.
 
-<img src="/docs/assets/news/multi_integ_1.png" height="500" decoding="async" loading="lazy"/>
-<img src="/docs/assets/news/multi_integ_2.png" height="500" decoding="async" loading="lazy"/>
+<img src="/docs/assets/news/multi_integ_1.png" width="440" height="500" decoding="async" loading="lazy"/>
+<img src="/docs/assets/news/multi_integ_2.png" width="380" height="500" decoding="async" loading="lazy"/>
 
 
 ---


### PR DESCRIPTION
### Describe the purpose of your pull request

Sets `height: auto` for all `<img>`s in the `article` section, except for the ones that have the `no-auto-height` class.

This is necessary to maintain the aspect ratio of the images embedded according to new [Screenshot Guide](https://github.com/configcat-labs/content-wiki/blob/main/screenshot-guide.md).

### Related issues (only if applicable)

n/a

### How to test? (only if applicable)

Check a few pages with images. Everything should exactly the same as before.

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
