### PR TITLE
Add cache warning to PHP SDK docs

### DIFF
--- a/website/docs/sdk-reference/php.mdx
+++ b/website/docs/sdk-reference/php.mdx
@@ -28,8 +28,17 @@ composer require configcat/configcat-client
 ### 2. Create the _ConfigCat_ client with your _SDK Key_
 
 ```php
-$client = new \ConfigCat\ConfigCatClient("#YOUR-SDK-KEY#");
+$client = new \ConfigCat\ConfigCatClient("#YOUR-SDK-KEY#", [
+  \ConfigCat\ClientOptions::CACHE => new \ConfigCat\Cache\LaravelCache(\Illuminate\Support\Facades\Cache::store()),
+]);
 ```
+
+:::warning
+Due to the nature of PHP, for each HTTP request, it spawns a dedicated PHP process that will instantiate a new ConfigCat client every time.
+Therefore, to avoid the download of all feature flag data at every initialization, it's crucial to set up appropriate caching.
+
+For more caching options, see the [Cache](#cache) section of this documentation.
+:::
 
 ### 3. Get your setting value
 

--- a/website/versioned_docs/version-V1/sdk-reference/php.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/php.mdx
@@ -34,8 +34,17 @@ composer require configcat/configcat-client
 ### 2. Create the _ConfigCat_ client with your _SDK Key_
 
 ```php
-$client = new \ConfigCat\ConfigCatClient("#YOUR-SDK-KEY#");
+$client = new \ConfigCat\ConfigCatClient("#YOUR-SDK-KEY#", [
+  \ConfigCat\ClientOptions::CACHE => new \ConfigCat\Cache\LaravelCache(\Illuminate\Support\Facades\Cache::store()),
+]);
 ```
+
+:::warning
+Due to the nature of PHP, for each HTTP request, it spawns a dedicated PHP process that will instantiate a new ConfigCat client every time.
+Therefore, to avoid the download of all feature flag data at every initialization, it's crucial to set up appropriate caching.
+
+For more caching options, see the [Cache](#cache) section of this documentation.
+:::
 
 ### 3. Get your setting value
 


### PR DESCRIPTION
### Describe the purpose of your pull request
- Add cache warning to PHP SDK docs.

### Related issues (only if applicable)
- https://trello.com/c/55lBRrAY/1427-php-sdk-cache-fontos-doksi-connect-app

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
