### PR TITLE
Fix broken deno SDK link in  schema markup

### DIFF
--- a/website/src/schema-markup/sdk-reference/community/deno.json
+++ b/website/src/schema-markup/sdk-reference/community/deno.json
@@ -1,8 +1,8 @@
 {
   "@context": "https://schema.org/",
   "@type": "HowTo",
-  "name": "How to use feature flags in Deno?",
-  "description": "How to use feature flags in Deno using ConfigCat Feature Flags.",
+  "name": "How to use feature flags in Deno applications?",
+  "description": "How to use feature flags in Deno applications using ConfigCat Feature Flags.",
   "image": "https://configcat.com/images/shared/home.png",
   "totalTime": "PT10M",
   "estimatedCost": {
@@ -30,17 +30,31 @@
     },
     {
       "@type": "HowToStep",
-      "text": "Import package",
+      "text": "Install and import package",
       "image": "https://configcat.com/images/shared/home.png",
-      "name": "Import",
-      "url": "https://configcat.com/docs/sdk-reference/community/deno/#usage"
+      "name": "Installation and import",
+      "url": "https://configcat.com/docs/sdk-reference/js/deno/#1-install-and-import-package"
     },
     {
       "@type": "HowToStep",
-      "text": "Create ConfigCat client and access feature flags",
+      "text": "Create the ConfigCat client with your SDK Key",
       "image": "https://configcat.com/images/shared/home.png",
-      "name": "Initialize and Evaluate",
-      "url": "https://configcat.com/docs/sdk-reference/community/deno/#usage"
+      "name": "Initialization",
+      "url": "https://configcat.com/docs/sdk-reference/js/deno/#2-create-the-configcat-client-with-your-sdk-key"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Get your setting value",
+      "image": "https://configcat.com/images/shared/home.png",
+      "name": "Evaluation",
+      "url": "https://configcat.com/docs/sdk-reference/js/deno/#3-get-your-setting-value"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Dispose ConfigCat client",
+      "image": "https://configcat.com/images/shared/home.png",
+      "name": "Dispose",
+      "url": "https://configcat.com/docs/sdk-reference/js/deno/#4-dispose-the-configcat-client"
     }
   ]
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fix broken deno SDK link in  schema markup. The broken link was: https://configcat.com/docs/sdk-reference/community/deno/ and I changed it to: https://configcat.com/docs/sdk-reference/js/deno/.

- Update the schema markup content in `website/src/schema-markup/sdk-reference/community/deno.json` to match the current one in `website/src/schema-markup/sdk-reference/js/deno.json`.

QUESTION:

- Is there any reason to have two schema markup for the same SDK in different folders as described above?

### Related issues (only if applicable)
- Provide links to issues relating to this pull request.

### How to test? (only if applicable)
- What part of the application was affected by the changes? What should be tested?

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
