### PR TITLE
fix addon prices on network traffic page

### DIFF
--- a/website/docs/network-traffic.mdx
+++ b/website/docs/network-traffic.mdx
@@ -112,9 +112,6 @@ The [CDN proxy](./advanced/proxy/endpoints.mdx#cdn-proxy) feature allows you to 
 
 ### Purchase additional network traffic
 
-You can purchase an add-on for your subscription to increase your limits. [Contact us](https://configcat.com/support/) for more information.
+If your application requires more network traffic than your current plan includes, you can purchase additional quota as an add-on. You can find the current add-on options [here](https://configcat.com/policies/billing/#pre-purchased-quota).
 
-| Plan           | Price              | Additional config JSON downloads | Additional network traffic |
-| -------------- | ------------------ | -------------------------------: | -------------------------: |
-| **Smart**      | $250 or €229 / mo  | +250 million                     | +1TB                       |
-| **Enterprise** | $700 or €649 / mo  | +1 billion                       | +4TB                       |
+[Contact us](https://configcat.com/support/) and we will help.

--- a/website/docs/network-traffic.mdx
+++ b/website/docs/network-traffic.mdx
@@ -47,6 +47,8 @@ Here are a few examples of config JSON file sizes:
     </tbody>
   </table>
 
+## Factors affecting Network Traffic
+
 #### Size of the `config JSON`
 It is affected by the number of feature flags, settings, targeting rules, segments, and the length of their values.
 


### PR DESCRIPTION
### Describe the purpose of your pull request
I added the same text as on config json download page in add-on section. 

### Related issues (only if applicable)
- Provide links to issues relating to this pull request.

### How to test? (only if applicable)
- What part of the application was affected by the changes? What should be tested?
- /docs/network-traffic/#purchase-additional-network-traffic

### Requirement checklist
- [ ] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
