### PR TITLE
Revamp menus

### DIFF
--- a/website/.validationignore
+++ b/website/.validationignore
@@ -35,6 +35,10 @@
 /docs/advanced/team-management/saml/identity-providers/okta.mdx
 /docs/advanced/team-management/saml/identity-providers/onelogin.mdx
 /docs/advanced/team-management/saml/overview.mdx
+/docs/advanced/team-management/scim/identity-providers/entra-id.mdx
+/docs/advanced/team-management/scim/identity-providers/okta.mdx
+/docs/advanced/team-management/scim/identity-providers/onelogin.mdx
+/docs/advanced/team-management/scim/overview.mdx
 /docs/advanced/team-management/single-sign-on-sso.mdx
 /docs/advanced/team-management/team-management-basics.mdx
 /docs/advanced/troubleshooting.mdx

--- a/website/docs/advanced/caching.mdx
+++ b/website/docs/advanced/caching.mdx
@@ -1,6 +1,6 @@
 ---
 id: caching
-title: Polling modes & Caching
+title: Polling Modes & Caching
 description: This section describes how to use the SDK's caching feature. There are three different polling modes available in the ConfigCat SDKs.
 ---
 

--- a/website/docs/advanced/team-management/auto-assign-users.mdx
+++ b/website/docs/advanced/team-management/auto-assign-users.mdx
@@ -1,6 +1,6 @@
 ---
 id: auto-assign-users
-title: Auto-assign Users
+title: Auto-Assign Users
 description: New users will be automatically added to your organization if you have a verified domain. Here is how to set it up.
 ---
 

--- a/website/docs/advanced/team-management/scim/overview.mdx
+++ b/website/docs/advanced/team-management/scim/overview.mdx
@@ -1,6 +1,6 @@
 ---
 id: scim-overview
-title: User provisioning (SCIM) Overview
+title: User Provisioning (SCIM) Overview
 description: This section is a step-by-step guide on how to configure User provisioning (SCIM) for your Organization in ConfigCat.
 ---
 

--- a/website/docs/advanced/variation-id-for-analytics.mdx
+++ b/website/docs/advanced/variation-id-for-analytics.mdx
@@ -1,6 +1,6 @@
 ---
 id: variation-id-for-analytics
-title: Variation ID for analytics
+title: Variation ID for Analytics
 description: Learn about how to utilize the Variation ID to enrich feature flag evaluation events.
 ---
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -287,7 +287,7 @@ const config: Config = {
       items: [
         {
           type: 'docSidebar',
-          label: 'Docs',
+          label: 'Product Docs',
           sidebarId: 'docs',
           position: 'left',
         },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -12,30 +12,7 @@ const docs: SidebarConfig = [
     items: [
       'getting-started',
       'main-concepts',
-      'purchase',
-      'requests',
-      'network-traffic',
       'organization',
-    ],
-  },
-  {
-    label: 'Guides',
-    type: 'category',
-    collapsed: false,
-    collapsible: true,
-    className: 'icon guides-icon',
-    items: [
-      {
-        label: 'Config V2',
-        type: 'category',
-        link: { type: 'doc', id: 'advanced/config-v2' },
-        items: [
-          'advanced/config-v2-migration-guide',
-          'advanced/config-v2-sdk-compatibility',
-        ],
-      },
-      'advanced/data-governance',
-      'advanced/predefined-variations',
       {
         label: 'Targeting',
         type: 'category',
@@ -59,9 +36,22 @@ const docs: SidebarConfig = [
           'targeting/feature-flag-evaluation',
         ],
       },
-      'advanced/variation-id-for-analytics',
+      'advanced/predefined-variations',
+    ],
+  },
+  {
+    label: 'Guides',
+    type: 'category',
+    collapsed: false,
+    collapsible: true,
+    className: 'icon guides-icon',
+    items: [
+      'purchase',
+      'requests',
+      'network-traffic',
       'advanced/caching',
-      'advanced/troubleshooting',
+      'advanced/data-governance',
+      'advanced/variation-id-for-analytics',
       'zombie-flags',
       {
         label: 'Migration from LaunchDarkly',
@@ -75,6 +65,16 @@ const docs: SidebarConfig = [
           },
         ],
       },
+      {
+        label: 'Config V2',
+        type: 'category',
+        link: { type: 'doc', id: 'advanced/config-v2' },
+        items: [
+          'advanced/config-v2-migration-guide',
+          'advanced/config-v2-sdk-compatibility',
+        ],
+      },
+      'advanced/troubleshooting',
     ],
   },
   {
@@ -136,7 +136,7 @@ const docs: SidebarConfig = [
         ],
       },
       {
-        label: 'User provisioning (SCIM)',
+        label: 'User Provisioning (SCIM)',
         type: 'category',
         link: {
           type: 'doc',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -8,33 +8,87 @@ import styles from './styles.module.css';
 
 const features = [
   {
+    column: 0,
     title: 'Basics',
     description: <>Familiarize with ConfigCat basics.</>,
     links: [
-      { url: 'getting-started', title: 'Getting started' },
+      { url: 'getting-started', title: 'Getting Started' },
       { url: 'main-concepts', title: 'Main Concepts' },
+      { url: 'organization', title: 'Organization & Roles' },
       { url: 'targeting/targeting-overview', title: 'Targeting' },
+      { url: 'advanced/predefined-variations', title: 'Predefined Variations vs Free‑Form Values' },
+    ],
+  },
+  {
+    column: 0,
+    cssClass: "last-on-mobile",
+    title: 'Plans & Usage',
+    description: <>The financial side of feature flagging.</>,
+    links: [
+      { url: 'purchase', title: 'Plans, Purchase & Billing' },
       { url: 'requests', title: 'What is a config JSON download?' },
       { url: 'network-traffic', title: 'Network Traffic' },
-      { url: 'purchase', title: 'Plans, Purchase & Billing' },
-      { url: 'organization', title: 'Organization & Roles' },
+    ],
+  },
+  {
+    column: 0,
+    cssClass: "last-on-mobile",
+    title: 'Further Reading',
+    description: <>Additional useful information.</>,
+    links: [
+      { url: 'advanced/config-v2-migration-guide', title: 'Config V2 Migration Guide' },
       { url: 'news', title: 'News & Product Updates' },
       { url: 'faq', title: 'FAQ' },
+      { url: 'advanced/troubleshooting', title: 'Troubleshooting' },
       { url: 'glossary', title: 'Glossary' },
     ],
   },
   {
-    title: 'Advanced Guides',
-    description: <>API, CLI, SAML, Webhooks...</>,
+    column: 1,
+    title: 'Advanced Features',
+    description: <>Boost your feature flagging efficiency.</>,
     links: [
-      { url: 'api/reference/configcat-public-management-api', title: 'Public Management API' },
+      { url: 'advanced/cli', title: 'Command Line Interface (CLI)' },
+      {
+        url: 'advanced/proxy/proxy-overview',
+        title: 'ConfigCat Proxy',
+      },
       { url: 'advanced/data-governance', title: 'Data Governance - CDN' },
-      { url: 'advanced/predefined-variations', title: 'Predefined Variations vs Free‑Form Values' },
-      { url: 'advanced/variation-id-for-analytics', title: 'Variation ID for analytics' },
-      { url: 'advanced/caching', title: 'Polling modes & Caching' },
+      {
+        url: 'advanced/migration-from-launchdarkly',
+        title: 'Migration from LaunchDarkly',
+      },
+      { url: 'advanced/mcp-server', title: 'MCP Server' },
+      {
+        url: 'advanced/notifications-webhooks',
+        title: 'Notifications - Webhooks',
+      },
+      { url: 'api/reference/configcat-public-management-api', title: 'Public Management API' },
+      {
+        url: 'advanced/code-references/overview',
+        title: 'Scan & Upload Code References',
+      },
+
+      { url: 'advanced/variation-id-for-analytics', title: 'Variation ID for Analytics' },
+      { url: 'zombie-flags', title: 'Zombie Flags' },
+    ],
+  },
+  {
+    column: 1,
+    title: 'Team Management',
+    description: <>Grant your team access to ConfigCat.</>,
+    links: [
       {
         url: 'advanced/team-management/team-management-basics',
-        title: 'Team Management',
+        title: 'Team Management Basics',
+      },
+      {
+        url: 'advanced/team-management/single-sign-on-sso',
+        title: 'SSO (Single Sign-On)',
+      },
+      {
+        url: 'advanced/team-management/auto-assign-users',
+        title: 'Auto-Assign Users',
       },
       {
         url: 'advanced/team-management/saml/saml-overview',
@@ -42,33 +96,17 @@ const features = [
       },
       {
         url: 'advanced/team-management/scim/scim-overview',
-        title: 'User provisioning (SCIM)',
+        title: 'User Provisioning (SCIM)',
       },
       {
-        url: 'advanced/notifications-webhooks',
-        title: 'Notifications - Webhooks',
+        url: 'advanced/team-management/domain-verification',
+        title: 'Domain Verification',
       },
-      { url: 'advanced/troubleshooting', title: 'Troubleshooting' },
-      { url: 'advanced/cli', title: 'Command Line Interface (CLI)' },
-      {
-        url: 'advanced/code-references/overview',
-        title: 'Scan & Upload Code References',
-      },
-      {
-        url: 'advanced/proxy/proxy-overview',
-        title: 'ConfigCat Proxy',
-      },
-      {
-        url: 'advanced/migration-from-launchdarkly',
-        title: 'Migration from LaunchDarkly',
-      },
-      { url: 'advanced/mcp-server', title: 'MCP Server' },
-      { url: 'zombie-flags', title: 'Zombie Flags' },
-      // { url: 'advanced/config-v2-migration-guide', title: 'Config V2 Migration Guide' },
     ],
   },
   {
-    title: 'SDK references', // This list should be in alphabetical order
+    column: 2,
+    title: 'SDK References', // This list should be in alphabetical order
     description: <>Let's do some coding.</>,
     links: [
       { url: 'sdk-reference/dotnet', title: '.NET' },
@@ -104,6 +142,7 @@ const features = [
     ],
   },
   {
+    column: 3,
     title: 'Integrations', // This list should be in alphabetical order
     description: <>Get connected to increase productivity.</>,
     links: [
@@ -135,29 +174,44 @@ const features = [
   },
 ];
 
-function Feature({ imageUrl, title, description, links }) {
-  const imgUrl = useBaseUrl(imageUrl);
+const featuresByColumn = features.reduce((acc, feature) => {
+  let group = acc[feature.column];
+  if (!group) acc[feature.column] = group = [];
+  group.push(feature);
+  return acc;
+}, []);
+
+function Feature({ features }) {
   return (
     <div className={clsx('col col--3', styles.feature)}>
-      {imgUrl && (
-        <div className="text--center">
-          <img className={clsx('no-auto-height', styles.featureImage)} src={imgUrl} alt={title} />
-        </div>
-      )}
-      <h3>{title}</h3>
-      <p>{description}</p>
-      {FeatureItems(links)}
+      {features
+        .map(({ cssClass, imageUrl, title, description, links }, idx) => {
+          const imgUrl = useBaseUrl(imageUrl);
+          return (
+            <div key={idx} className={clsx(cssClass, styles.featureSection)}>
+              {imgUrl && (
+                <div className="text--center">
+                  <img className={clsx('no-auto-height', styles.featureImage)} src={imgUrl} alt={title} />
+                </div>
+              )}
+              <h3>{title}</h3>
+              <p>{description}</p>
+              <FeatureItems links={links} />
+            </div>
+          );
+        })
+      }
     </div>
   );
 }
 
-function FeatureItems(links) {
+function FeatureItems({ links }) {
   return (
-    <ul class="feature-list">
-      {links.map(({ url, title, items }) => (
-        <li>
+    <ul className="feature-list">
+      {links.map(({ url, title, items }, idx) => (
+        <li key={idx}>
           <Link to={useBaseUrl(url)}>{title}</Link>
-          {items?.length && FeatureItems(items)}
+          {items?.length && <FeatureItems links={items} />}
         </li>
       ))}
     </ul>
@@ -189,24 +243,24 @@ function Home() {
               )}
               to={useBaseUrl('getting-started')}
             >
-              Open Docs
+              Get started
             </Link>
           </div>
         </div>
       </header>
       <main>
-        {features && features.length > 0 && (
           <section className={styles.features}>
             <div className="container">
-              <h2 className="text--center">Quick links</h2>
               <div className="row">
-                {features.map((props, idx) => (
-                  <Feature key={idx} {...props} />
-                ))}
+              {featuresByColumn
+                .filter(group => group.length)
+                .map((group, idx) => (
+                  <Feature key={idx} features={group} />
+                ))
+              }
               </div>
             </div>
           </section>
-        )}
       </main>
     </Layout>
   );

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -10,7 +10,7 @@ const features = [
   {
     column: 0,
     title: 'Basics',
-    description: <>Familiarize with ConfigCat basics.</>,
+    description: <>Learn the fundamentals of ConfigCat.</>,
     links: [
       { url: 'getting-started', title: 'Getting Started' },
       { url: 'main-concepts', title: 'Main Concepts' },
@@ -139,6 +139,7 @@ const features = [
       { url: 'sdk-reference/ios', title: 'Swift (iOS)' },
       { url: 'sdk-reference/unity', title: 'Unity' },
       { url: 'sdk-reference/unreal', title: 'Unreal Engine' },
+      { url: 'sdk-reference/openfeature', title: 'OpenFeature Providers' },
     ],
   },
   {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -45,7 +45,7 @@ const features = [
   },
   {
     column: 1,
-    title: 'Advanced Features',
+    title: 'Advanced Features', // This list should be in alphabetical order
     description: <>Boost your feature flagging efficiency.</>,
     links: [
       { url: 'advanced/cli', title: 'Command Line Interface (CLI)' },

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -25,6 +25,28 @@
   width: 100%;
 }
 
+.featureSection {
+  margin-bottom: 1.5rem;
+}
+
+@media screen and (max-width: 996px) {
+  .features > :global(.container > .row) {
+    flex-direction: column;
+  }
+
+  .features > :global(.container > .row > .col) {
+    display: contents;
+  }
+
+  .features > :global(.container > .row > .col > div) {
+    padding: 0 var(--ifm-spacing-horizontal);
+  }
+
+  .featureSection:global(.last-on-mobile) {
+    order: 1000;
+  }
+}
+
 .featureImage {
   height: 200px;
   width: 200px;

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -26,7 +26,11 @@
 }
 
 .featureSection {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.74rem;
+}
+
+.featureSection > :global(p) {
+  --ifm-paragraph-margin-bottom: 0.75rem;
 }
 
 @media screen and (max-width: 996px) {

--- a/website/versioned_docs/version-V1/advanced/caching.mdx
+++ b/website/versioned_docs/version-V1/advanced/caching.mdx
@@ -1,6 +1,6 @@
 ---
 id: caching
-title: Polling modes & Caching
+title: Polling Modes & Caching
 description: This section describes how to use the SDK's caching feature. There are three different polling modes available in the ConfigCat SDKs.
 ---
 

--- a/website/versioned_docs/version-V1/advanced/team-management/auto-assign-users.mdx
+++ b/website/versioned_docs/version-V1/advanced/team-management/auto-assign-users.mdx
@@ -1,6 +1,6 @@
 ---
 id: auto-assign-users
-title: Auto-assign Users
+title: Auto-Assign Users
 description: New users will be automatically added to your organization if you have a verified domain. Here is how to set it up.
 ---
 

--- a/website/versioned_docs/version-V1/advanced/team-management/scim/overview.mdx
+++ b/website/versioned_docs/version-V1/advanced/team-management/scim/overview.mdx
@@ -1,6 +1,6 @@
 ---
 id: scim-overview
-title: User provisioning (SCIM) Overview
+title: User Provisioning (SCIM) Overview
 description: This section is a step-by-step guide on how to configure User provisioning (SCIM) for your Organization in ConfigCat.
 ---
 

--- a/website/versioned_sidebars/version-V1-sidebars.json
+++ b/website/versioned_sidebars/version-V1-sidebars.json
@@ -9,10 +9,10 @@
       "items": [
         "getting-started",
         "main-concepts",
-        "purchase",
-        "requests",
-        "network-traffic",
-        "organization"
+        "organization",
+        "advanced/targeting",
+        "advanced/segments",
+        "advanced/user-object"
       ]
     },
     {
@@ -34,13 +34,13 @@
             "advanced/config-v2-sdk-compatibility"
           ]
         },
-        "advanced/data-governance",
-        "advanced/targeting",
-        "advanced/segments",
-        "advanced/user-object",
+        "purchase",
+        "requests",
+        "network-traffic",
         "advanced/caching",
-        "advanced/troubleshooting",
-        "zombie-flags"
+        "advanced/data-governance",
+        "zombie-flags",
+        "advanced/troubleshooting"
       ]
     },
     {
@@ -105,7 +105,7 @@
           ]
         },
         {
-          "label": "User provisioning (SCIM)",
+          "label": "User Provisioning (SCIM)",
           "type": "category",
           "link": {
             "type": "doc",


### PR DESCRIPTION
### Describe the purpose of your pull request
Revamps index page and sidebar menus:
- Changes CTA button test from "Open Docs" to "Get started" (as agreed by the UX team)
- Removes the "Quick Links" text above the link sections.
- Revises the Basics section so it contains documents necessary to actually get started working with the product.
- Extracts other documents into separate sections ("Further Reading", etc.)
- Changes the section title "Advanced Guides" to "Advanced Features".
- Sorts links in alphabetical order in the "Advanced Features" section.
- Extracts permission and team management-related topics into a separate section "Team Management".
- Reorganizes the Basics section in the sidebar menu to match the main menu.
- Reorganizes the Guides section in the sidebar menu.

Also, corrects page titles according to the text guidelines (consistent title case).

### Related issues (only if applicable)
https://trello.com/c/82bY4SWo

### How to test? (only if applicable)
Check the menus in V1 & V2 on multiple screen sizes.

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
