### PR TITLE
Fix MDX syntax highlighting and code navigation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,6 @@
     "files.associations": {
       "*.mdx": "mdx"
     },
-    "mdx.experimentalLanguageServer": true,
-    "typescript.tsserver.experimental.enableProjectDiagnostics": true
+    "mdx.server.enable": true,
+    "js/ts.tsserver.experimental.enableProjectDiagnostics": false
 }

--- a/website/docs/advanced/proxy/monitoring.mdx
+++ b/website/docs/advanced/proxy/monitoring.mdx
@@ -75,7 +75,7 @@ CONFIGCAT_DIAG_PORT=8051
 </tbody>
 </table>
 
-## Status Endpoint {#status}
+## Status Endpoint {/* #status */}
 
 The Proxy provides status information (health check) about its components on the following endpoint:
 
@@ -226,7 +226,7 @@ CONFIGCAT_DIAG_METRICS_ENABLED=<true|false>
 </tbody>
 </table>
 
-### Prometheus {#prometheus-metrics}
+### Prometheus {/* #prometheus-metrics */}
 
 You can set up the Proxy to export metrics about its internal state in Prometheus format. These metrics are served on the `/metrics` endpoint.
 

--- a/website/docs/advanced/proxy/overview.mdx
+++ b/website/docs/advanced/proxy/overview.mdx
@@ -119,7 +119,7 @@ You can decide where you want the actual feature flag evaluation to happen.
 <Steps>
 <Step>
 <Title>
-### Local evaluation using a ConfigCat SDK connected to the Proxy {#1-local-evaluation-using-a-configcat-sdk-connected-to-the-proxy}
+### Local evaluation using a ConfigCat SDK connected to the Proxy {/* #1-local-evaluation-using-a-configcat-sdk-connected-to-the-proxy */}
 </Title>
 
 The Proxy has the ability to forward all information required for feature flag evaluation to ConfigCat SDKs via its [CDN proxy](endpoints.mdx#cdn-proxy) endpoint. 
@@ -157,7 +157,7 @@ var configCatClient = configcat.getClient(
 
 <Step>
 <Title>
-### Remote evaluation with the Proxy's API endpoints {#2-remote-evaluation-with-the-proxys-api-endpoints}
+### Remote evaluation with the Proxy's API endpoints {/* #2-remote-evaluation-with-the-proxys-api-endpoints */}
 </Title>
 
 You can leverage the Proxy's server side feature flag evaluation feature by sending simple HTTP requests to the Proxy's API endpoints.
@@ -228,7 +228,7 @@ You can find the available API endpoints with their HTTP request/response schema
 
 <Step>
 <Title>
-### Remote evaluation with OpenFeature Remote Evaluation Protocol (OFREP) {#3-remote-evaluation-with-openfeature-remote-evaluation-protocol-ofrep}
+### Remote evaluation with OpenFeature Remote Evaluation Protocol (OFREP) {/* #3-remote-evaluation-with-openfeature-remote-evaluation-protocol-ofrep */}
 </Title>
 
 :::info
@@ -278,7 +278,7 @@ You can find the available OFREP endpoints with their HTTP request/response sche
 
 <Step>
 <Title>
-### Remote evaluation and streaming with SSE {#4-remote-evaluation-and-streaming-with-sse}
+### Remote evaluation and streaming with SSE {/* #4-remote-evaluation-and-streaming-with-sse */}
 </Title>
 
 The Proxy has the ability to evaluate feature flags and send notifications about subsequent evaluated flag value changes through <a target="blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events">Server-Sent Events</a> connections.
@@ -330,7 +330,7 @@ For more information and usage examples, see the related [SSE endpoints document
 
 <Step>
 <Title>
-### Remote evaluation and streaming with gRPC {#5-remote-evaluation-and-streaming-with-grpc}
+### Remote evaluation and streaming with gRPC {/* #5-remote-evaluation-and-streaming-with-grpc */}
 </Title>
 
 The Proxy supports both unary feature flag evaluation RPCs and server streaming of evaluated flag value changes.
@@ -479,12 +479,12 @@ Then start the Proxy:
 
 The following sections will go through each available option in detail.
 
-## How does the Proxy learn about feature flags? {#sdk}
+## How does the Proxy learn about feature flags? {/* #sdk */}
 
 In order to make the Proxy work properly, it must be set up with one or more <a target="blank" href="https://app.configcat.com/sdkkey">SDK keys</a>. 
 It creates one SDK instance per SDK key internally and uses those for feature flag evaluation. 
 
-### SDK Identifier {#sdk-identifier--sdk-key}
+### SDK Identifier {/* #sdk-identifier--sdk-key */}
 
 Within the Proxy, <a target="blank" href="https://app.configcat.com/sdkkey">SDK keys</a> are mapped to unique SDK identifiers. 
 
@@ -497,7 +497,7 @@ There are two ways to let the Proxy know which SDK Keys it should use:
 <Steps>
 <Step>
 <Title>
-### Automatic configuration with Proxy profiles {#1-automatic-configuration-with-proxy-profiles}
+### Automatic configuration with Proxy profiles {/* #1-automatic-configuration-with-proxy-profiles */}
 </Title>
 
 :::info
@@ -889,7 +889,7 @@ To connect a Proxy instance to a Proxy profile, follow these steps:
 </Step>
 <Step>
 <Title>
-### Manual configuration {#2-manual-configuration}
+### Manual configuration {/* #2-manual-configuration */}
 </Title>
 
 When using environment variables, the SDK keys can be specified as a JSON object, where the **property name is the SDK identifier** (the identifier of the config-environment pair whose SDK Key the underlying SDK instance is configured to use) and the **property value is the actual SDK key**.

--- a/website/docs/advanced/team-management/scim/overview.mdx
+++ b/website/docs/advanced/team-management/scim/overview.mdx
@@ -21,7 +21,7 @@ Go to the **User provisioning (SCIM)** section on the <a href="https://app.confi
 
 Check our User Provisioning (SCIM) API documentation [here](/api/scim/configcat-user-provisioning-scim-api/).
 
-## 1. Connect your Identity Provider {#connect}
+## 1. Connect your Identity Provider {/* #connect */}
 
 To enable SCIM in your Identity Provider, you have to let it know where ConfigCat accepts SCIM endpoint calls and how these calls are authorized.
 Configcat displays this information on its <a href="https://app.configcat.com/organization/authentication/" target="_blank" rel="noopener noreferrer">Authentication & Provisioning</a> page,
@@ -51,7 +51,7 @@ Other Identity Providers might also work with ConfigCat, if they support the SCI
 Connecting your Identity Provider and starting to sync users and groups is safe. It won't affect your current ConfigCat users or permissions until you click the `START PROVISIONING` button later.
 :::
 
-## 2. Assign ConfigCat permissions to Identity Provider groups  {#groups}
+## 2. Assign ConfigCat permissions to Identity Provider groups  {/* #groups */}
 
 After the first successful sync, your Identity Provider groups will show up in ConfigCat. You will find them in the **2. Assign ConfigCat permissions to Identity Provider groups** section of the <a href="https://app.configcat.com/organization/authentication/" target="_blank" rel="noopener noreferrer">Authentication & Provisioning</a> page.
 For each Identity Provider group, you can assign ConfigCat permissions by clicking their gear icon.
@@ -105,7 +105,7 @@ Based on their *Identity Provider groups*, users will get the following *ConfigC
 | Jane                   | Readers, Billing Managers | Billing Manager, Product A/Readers, Product B/Readers   | Jane gets both Billing Manager and product-level permissions. These are merged from her groups. |
 | Peter                  | Readers, Developers       | Product A/Developers, Product B/Developers              | As both the Readers and Developers Identity Provider groups have associated permissions to the same Products, the permissions will be merged based on the Identity Provider group's priority. |
 
-## 3. Start and stop provisioning for Identity Provider users  {#users}
+## 3. Start and stop provisioning for Identity Provider users  {/* #users */}
 
 After successful synchronization, Identity Provider users will appear in ConfigCat. You can find them in the **3. Start and stop provisioning for Identity Provider users** section of the <a href="https://app.configcat.com/organization/authentication/" target="_blank" rel="noopener noreferrer">Authentication & Provisioning</a> page.
 You can see and control their provisioning state there. 
@@ -162,7 +162,7 @@ After the provisioning is started again, the **provisioning status** can take th
 - **Provisioning is active**: all permissions and user properties match your Identity Provider configuration for the *Identity Provider user*.
 - **Provisioning is in progress**: the provisioning process is running in the background. For a short time, you can see the **provisioning is in progress** status. This happens when your Identity Provider sends updates to ConfigCat about the *Identity Provider user*, or when you modify your *Identity Provider group*'s provisioning permissions.
 
-## 4. Provision future users automatically {#auto-provisioning}
+## 4. Provision future users automatically {/* #auto-provisioning */}
 
 By default, after the Identity Provider synchronizes a new Identity Provider user to ConfigCat, the Identity Provider user will be in the **provisioning stopped** state. This allows you time to verify your configuration/permissions and adjust your settings if needed.  
 After you are confident that the provisioning works as expected, you can turn ON the **Provision future users automatically** toggle. This will immediately start the provisioning for newly synchronized Identity Provider users. 
@@ -179,7 +179,7 @@ If you want to allow only provisioned users into your ConfigCat Organization, yo
 
 <img className="bordered-img" src="/docs/assets/scim/dashboard/disable_auto_assign.png" alt="Disable domain auto-assign" decoding="async" loading="lazy"/>
 
-## 5. Review ConfigCat users who are not managed by user provisioning  {#not-managed}
+## 5. Review ConfigCat users who are not managed by user provisioning  {/* #not-managed */}
 
 Even after configuring *user provisioning* and synchronizing *Identity Provider users* from your Identity Provider, there might be *ConfigCat accounts* in your Organization that are not managed by *user provisioning*.
 

--- a/website/docs/integrations/amplitude.mdx
+++ b/website/docs/integrations/amplitude.mdx
@@ -15,7 +15,7 @@ There are two available integration opportunities between ConfigCat and Amplitud
 - [Monitoring your feature flag change events in Amplitude with Annotations](#annotations)
 - [Sending feature flag evaluation analytics to Amplitude Experiments](#experiments)
 
-## Monitoring your feature flag change events in Amplitude with Annotations {#annotations}
+## Monitoring your feature flag change events in Amplitude with Annotations {/* #annotations */}
 
 Every feature flag change in ConfigCat is annotated on the Amplitude charts as a vertical line and some details are added automatically about the change.
 
@@ -72,7 +72,7 @@ Every annotation sent to Amplitude by ConfigCat has:
 <img src="/docs/assets/amplitude_annotation.png" className="bordered-img" alt="amplitude_annotation" decoding="async" loading="lazy"/>
 
 
-## Sending feature flag evaluation analytics to Amplitude Experiments {#experiments}
+## Sending feature flag evaluation analytics to Amplitude Experiments {/* #experiments */}
 
 Ensures that feature flag evaluations are logged into <a href="https://amplitude.com/docs/experiment/" target="_blank" rel="noopener noreferrer">Amplitude Experiments</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
 

--- a/website/docs/integrations/mixpanel.mdx
+++ b/website/docs/integrations/mixpanel.mdx
@@ -15,7 +15,7 @@ There are two available integration opportunities between [ConfigCat and Mixpane
 - [Monitoring your feature flag change events in Mixpanel with Annotations](#annotations)
 - [Sending feature flag evaluation analytics to Mixpanel Experiments](#experiments)
 
-## Monitoring your feature flag change events in Mixpanel with Annotations {#annotations}
+## Monitoring your feature flag change events in Mixpanel with Annotations {/* #annotations */}
 
 Ensures that every setting change in ConfigCat is sent to Mixpanel as an [Annotation](https://docs.mixpanel.com/docs/reports/insights#annotations).
 
@@ -60,7 +60,7 @@ Every annotation sent to Mixpanel by ConfigCat has:
 - **Date:** When the change happened
 - **Description:** A brief summary of the change.
 
-## Sending feature flag evaluation analytics to Mixpanel Experiments {#experiments}
+## Sending feature flag evaluation analytics to Mixpanel Experiments {/* #experiments */}
 
 Ensures that feature flag evaluations are logged into [Mixpanel Experiments](https://docs.mixpanel.com/docs/reports/apps/experiments). With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
 

--- a/website/docs/integrations/segment.mdx
+++ b/website/docs/integrations/segment.mdx
@@ -15,7 +15,7 @@ There are two available integration opportunities between [ConfigCat and Twilio 
 - [Sending feature flag change events to Twilio Segment](#changeevents)
 - [Sending feature flag evaluation analytics to Twilio Segment](#analytics)
 
-## Sending feature flag change events to Twilio Segment {#changeevents}
+## Sending feature flag change events to Twilio Segment {/* #changeevents */}
 
 Ensures that every setting change in ConfigCat is sent to Segment as a <a href="https://segment.com/docs/connections/spec/track/" target="_blank" rel="noopener noreferrer">track event</a>.
 
@@ -67,7 +67,7 @@ Every feature flag change event sent to Twilio Segment by ConfigCat has the foll
 - **url**: A direct link to the config/feature flag.
 - **userId, user_email, user_full_name**: Who made the changes.
 
-## Sending feature flag evaluation analytics to Twilio Segment {#analytics}
+## Sending feature flag evaluation analytics to Twilio Segment {/* #analytics */}
 
 Ensures that feature flag evaluations are sent into the Twilio Segment <a href="https://segment.com/catalog/integrations/source/configcat/" target="_blank" rel="noopener noreferrer">ConfigCat source</a>. With this integration, you get advanced analytics on your feature flag usage and A/B test results in any of Segment's destinations.
 

--- a/website/docs/sdk-reference/android.mdx
+++ b/website/docs/sdk-reference/android.mdx
@@ -148,7 +148,7 @@ It is important to provide an argument for the `classOfT` parameter, specificall
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`    |
 | -------------- |-----------------------|
@@ -706,7 +706,7 @@ If you do not want to expose the SDK key or the content of the config JSON file,
 
 Also, we recommend using [confidential targeting comparators](../targeting/targeting-rule/user-condition.mdx#confidential-text-comparators) in the Targeting Rules of those feature flags that are used in the frontend/mobile SDKs.
 
-## Sample App {#sample-apps}
+## Sample App {/* #sample-apps */}
 
 <a href="https://github.com/configcat/android-sdk/tree/master/samples" target="_blank">Android App with auto polling and change listener</a>
 

--- a/website/docs/sdk-reference/cpp.mdx
+++ b/website/docs/sdk-reference/cpp.mdx
@@ -142,7 +142,7 @@ It is important to choose the correct `getValue` overload, where the type of the
 matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type of `defaultValue`        |
 | -------------- | ----------------------------- |

--- a/website/docs/sdk-reference/dart.mdx
+++ b/website/docs/sdk-reference/dart.mdx
@@ -160,7 +160,7 @@ It is important to provide an argument for the `defaultValue` parameter, specifi
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T` |
 | -------------- |--------------------|

--- a/website/docs/sdk-reference/dotnet.mdx
+++ b/website/docs/sdk-reference/dotnet.mdx
@@ -161,7 +161,7 @@ It is important to provide an argument for the `defaultValue` parameter, specifi
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`                |
 | -------------- | --------------------------------- |
@@ -921,7 +921,7 @@ IConfigCatClient client = ConfigCatClient.Get("#YOUR-SDK-KEY#", options =>
 The .NET SDK supports *shared caching*. You can read more about this feature and the required minimum SDK versions [here](../advanced/caching.mdx#shared-cache).
 :::
 
-## Using ConfigCat behind a proxy {#using-configcat-behind-a-proxy}
+## Using ConfigCat behind a proxy {/* #using-configcat-behind-a-proxy */}
 
 Provide your own network credentials (username/password) and proxy server settings (proxy server/port) by setting the
 `Proxy` property in the setup callback of `ConfigCatClient.Get`.

--- a/website/docs/sdk-reference/elixir.mdx
+++ b/website/docs/sdk-reference/elixir.mdx
@@ -102,7 +102,7 @@ value = ConfigCat.get_value(
 )
 ```
 
-## Anatomy of `get_value_details()` {#anatomy-of-getvaluedetails}
+## Anatomy of `get_value_details()` {/* #anatomy-of-getvaluedetails */}
 
 `get_value_details()` is similar to `get_value()` but instead of returning the evaluated value only, it gives more detailed information about the evaluation result.
 

--- a/website/docs/sdk-reference/ios.mdx
+++ b/website/docs/sdk-reference/ios.mdx
@@ -312,7 +312,7 @@ It is important to provide an argument for the `defaultValue` parameter, specifi
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `Value` |
 | -------------- | ---------------------- |

--- a/website/docs/sdk-reference/java.mdx
+++ b/website/docs/sdk-reference/java.mdx
@@ -153,7 +153,7 @@ It is important to provide an argument for the `classOfT` parameter, specificall
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`    |
 | -------------- |-----------------------|

--- a/website/docs/sdk-reference/js-ssr.mdx
+++ b/website/docs/sdk-reference/js-ssr.mdx
@@ -185,7 +185,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/docs/sdk-reference/js.mdx
+++ b/website/docs/sdk-reference/js.mdx
@@ -203,7 +203,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/docs/sdk-reference/js/_template.mdx
+++ b/website/docs/sdk-reference/js/_template.mdx
@@ -483,7 +483,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/docs/sdk-reference/kotlin.mdx
+++ b/website/docs/sdk-reference/kotlin.mdx
@@ -149,7 +149,7 @@ It is important to provide an argument for the `defaultValue` parameter, specifi
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`     |
 | -------------- |------------------------|

--- a/website/docs/sdk-reference/node.mdx
+++ b/website/docs/sdk-reference/node.mdx
@@ -186,7 +186,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/docs/sdk-reference/python.mdx
+++ b/website/docs/sdk-reference/python.mdx
@@ -115,7 +115,7 @@ value = client.get_value(
 )
 ```
 
-## Anatomy of `get_value_details()` {#anatomy-of-getvaluedetails}
+## Anatomy of `get_value_details()` {/* #anatomy-of-getvaluedetails */}
 
 `get_value_details()` is similar to `get_value()` but instead of returning the evaluated value only, it gives an _EvaluationDetails_ 
 object with more detailed information about the evaluation result.

--- a/website/docs/sdk-reference/react.mdx
+++ b/website/docs/sdk-reference/react.mdx
@@ -199,7 +199,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |
@@ -675,7 +675,7 @@ useEffect(() => {
 });
 ```
 
-## SDK Hooks (not React Hooks) {#hooks}
+## SDK Hooks (not React Hooks) {/* #hooks */}
 
 :::info
 _ConfigCat SDK_ hooks are not the same as React Hooks.

--- a/website/docs/sdk-reference/ruby.mdx
+++ b/website/docs/sdk-reference/ruby.mdx
@@ -113,7 +113,7 @@ value = client.get_value(
 );
 ```
 
-## Anatomy of `get_value_details` {#anatomy-of-getvaluedetails}
+## Anatomy of `get_value_details` {/* #anatomy-of-getvaluedetails */}
 
 `get_value_details` is similar to `get_value` but instead of returning the evaluated value only, it gives an _EvaluationDetails_
 object with more detailed information about the evaluation result.

--- a/website/docs/sdk-reference/rust.mdx
+++ b/website/docs/sdk-reference/rust.mdx
@@ -132,7 +132,7 @@ It is important to provide an argument for the `default` parameter, specifically
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`      |
 | -------------- | ----------------------- |

--- a/website/versioned_docs/version-V1/advanced/proxy/monitoring.mdx
+++ b/website/versioned_docs/version-V1/advanced/proxy/monitoring.mdx
@@ -125,7 +125,7 @@ CONFIGCAT_DIAG_METRICS_ENABLED=<true|false>
 </tbody>
 </table>
 
-## Status Endpoint {#status}
+## Status Endpoint {/* #status */}
 
 The Proxy provides status information (health check) about its components on the following endpoint:
 

--- a/website/versioned_docs/version-V1/advanced/team-management/scim/overview.mdx
+++ b/website/versioned_docs/version-V1/advanced/team-management/scim/overview.mdx
@@ -21,7 +21,7 @@ Go to the **User provisioning (SCIM)** section on the <a href="https://app.confi
 
 Check our User Provisioning (SCIM) API documentation [here](/api/scim/configcat-user-provisioning-scim-api/).
 
-## 1. Connect your Identity Provider {#connect}
+## 1. Connect your Identity Provider {/* #connect */}
 
 To enable SCIM in your Identity Provider, you have to let it know where ConfigCat accepts SCIM endpoint calls and how these calls are authorized.
 Configcat displays this information on its <a href="https://app.configcat.com/organization/authentication/" target="_blank" rel="noopener noreferrer">Authentication & Provisioning</a> page,
@@ -51,7 +51,7 @@ Other Identity Providers might also work with ConfigCat, if they support the SCI
 Connecting your Identity Provider and starting to sync users and groups is safe. It won't affect your current ConfigCat users or permissions until you click the `START PROVISIONING` button later.
 :::
 
-## 2. Assign ConfigCat permissions to Identity Provider groups  {#groups}
+## 2. Assign ConfigCat permissions to Identity Provider groups  {/* #groups */}
 
 After the first successful sync, your Identity Provider groups will show up in ConfigCat. You will find them in the **2. Assign ConfigCat permissions to Identity Provider groups** section of the <a href="https://app.configcat.com/organization/authentication/" target="_blank" rel="noopener noreferrer">Authentication & Provisioning</a> page.
 For each Identity Provider group, you can assign ConfigCat permissions by clicking their gear icon.
@@ -105,7 +105,7 @@ Based on their *Identity Provider groups*, users will get the following *ConfigC
 | Jane                   | Readers, Billing Managers | Billing Manager, Product A/Readers, Product B/Readers   | Jane gets both Billing Manager and product-level permissions. These are merged from her groups. |
 | Peter                  | Readers, Developers       | Product A/Developers, Product B/Developers              | As both the Readers and Developers Identity Provider groups have associated permissions to the same Products, the permissions will be merged based on the Identity Provider group's priority. |
 
-## 3. Start and stop provisioning for Identity Provider users  {#users}
+## 3. Start and stop provisioning for Identity Provider users  {/* #users */}
 
 After successful synchronization, Identity Provider users will appear in ConfigCat. You can find them in the **3. Start and stop provisioning for Identity Provider users** section of the <a href="https://app.configcat.com/organization/authentication/" target="_blank" rel="noopener noreferrer">Authentication & Provisioning</a> page.
 You can see and control their provisioning state there. 
@@ -162,7 +162,7 @@ After the provisioning is started again, the **provisioning status** can take th
 - **Provisioning is active**: all permissions and user properties match your Identity Provider configuration for the *Identity Provider user*.
 - **Provisioning is in progress**: the provisioning process is running in the background. For a short time, you can see the **provisioning is in progress** status. This happens when your Identity Provider sends updates to ConfigCat about the *Identity Provider user*, or when you modify your *Identity Provider group*'s provisioning permissions.
 
-## 4. Provision future users automatically {#auto-provisioning}
+## 4. Provision future users automatically {/* #auto-provisioning */}
 
 By default, after the Identity Provider synchronizes a new Identity Provider user to ConfigCat, the Identity Provider user will be in the **provisioning stopped** state. This allows you time to verify your configuration/permissions and adjust your settings if needed.  
 After you are confident that the provisioning works as expected, you can turn ON the **Provision future users automatically** toggle. This will immediately start the provisioning for newly synchronized Identity Provider users. 
@@ -179,7 +179,7 @@ If you want to allow only provisioned users into your ConfigCat Organization, yo
 
 <img className="bordered-img" src="/docs/assets/scim/dashboard/disable_auto_assign.png" alt="Disable domain auto-assign" decoding="async" loading="lazy"/>
 
-## 5. Review ConfigCat users who are not managed by user provisioning  {#not-managed}
+## 5. Review ConfigCat users who are not managed by user provisioning  {/* #not-managed */}
 
 Even after configuring *user provisioning* and synchronizing *Identity Provider users* from your Identity Provider, there might be *ConfigCat accounts* in your Organization that are not managed by *user provisioning*.
 

--- a/website/versioned_docs/version-V1/integrations/amplitude.mdx
+++ b/website/versioned_docs/version-V1/integrations/amplitude.mdx
@@ -14,7 +14,7 @@ There are two available integration opportunities between ConfigCat and Amplitud
 - [Monitoring your feature flag change events in Amplitude with Annotations](#annotations)
 - [Sending feature flag evaluation analytics to Amplitude Experiments](#experiments)
 
-## Monitoring your feature flag change events in Amplitude with Annotations {#annotations}
+## Monitoring your feature flag change events in Amplitude with Annotations {/* #annotations */}
 
 Every feature flag change in ConfigCat is annotated on the Amplitude charts as a vertical line and some details are added automatically about the change.
 
@@ -44,7 +44,7 @@ Every annotation sent to Amplitude by ConfigCat has:
 <img src="/docs/assets/amplitude_annotation.png" className="bordered-img" alt="amplitude_annotation" decoding="async" loading="lazy" />
 
 
-## Sending feature flag evaluation analytics to Amplitude Experiments {#experiments}
+## Sending feature flag evaluation analytics to Amplitude Experiments {/* #experiments */}
 
 Ensures that feature flag evaluations are logged into <a href="https://amplitude.com/docs/experiment/" target="_blank" rel="noopener noreferrer">Amplitude Experiments</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
 

--- a/website/versioned_docs/version-V1/integrations/mixpanel.mdx
+++ b/website/versioned_docs/version-V1/integrations/mixpanel.mdx
@@ -14,7 +14,7 @@ There are two available integration opportunities between [ConfigCat and Mixpane
 - [Monitoring your feature flag change events in Mixpanel with Annotations](#annotations)
 - [Sending feature flag evaluation analytics to Mixpanel Experiments](#experiments)
 
-## Monitoring your feature flag change events in Mixpanel with Annotations {#annotations}
+## Monitoring your feature flag change events in Mixpanel with Annotations {/* #annotations */}
 
 Ensures that every setting change in ConfigCat is sent to Mixpanel as an [Annotation](https://docs.mixpanel.com/docs/reports/insights#annotations).
 
@@ -42,7 +42,7 @@ Every annotation sent to Mixpanel by ConfigCat has:
 - **Date:** When the change happened
 - **Description:** A brief summary of the change.
 
-## Sending feature flag evaluation analytics to Mixpanel Experiments {#experiments}
+## Sending feature flag evaluation analytics to Mixpanel Experiments {/* #experiments */}
 
 Ensures that feature flag evaluations are logged into [Mixpanel Experiments](https://docs.mixpanel.com/docs/reports/apps/experiments). With this integration, you can have advanced analytics about your feature flag usages, A/B test results.
 

--- a/website/versioned_docs/version-V1/integrations/segment.mdx
+++ b/website/versioned_docs/version-V1/integrations/segment.mdx
@@ -14,7 +14,7 @@ There are two available integration opportunities between [ConfigCat and Twilio 
 - [Sending feature flag change events to Twilio Segment](#changeevents)
 - [Sending feature flag evaluation analytics to Twilio Segment](#analytics)
 
-## Sending feature flag change events to Twilio Segment {#changeevents}
+## Sending feature flag change events to Twilio Segment {/* #changeevents */}
 
 Ensures that every setting change in ConfigCat is sent to Segment as a <a href="https://segment.com/docs/connections/spec/track/" target="_blank" rel="noopener noreferrer">track event</a>.
 
@@ -47,7 +47,7 @@ Every feature flag change event sent to Twilio Segment by ConfigCat has the foll
 - **url**: A direct link to the config/feature flag.
 - **userId, user_email, user_full_name**: Who made the changes.
 
-## Sending feature flag evaluation analytics to Twilio Segment {#analytics}
+## Sending feature flag evaluation analytics to Twilio Segment {/* #analytics */}
 
 Ensures that feature flag evaluations are sent into the Twilio Segment <a href="https://segment.com/catalog/integrations/source/configcat/" target="_blank" rel="noopener noreferrer">ConfigCat source</a>. With this integration, you can have advanced analytics about your feature flag usages, A/B test results in any of Segment's destinations.
 

--- a/website/versioned_docs/version-V1/sdk-reference/android.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/android.mdx
@@ -153,7 +153,7 @@ It is important to provide an argument for the `classOfT` parameter, specificall
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`    |
 | -------------- |-----------------------|
@@ -642,7 +642,7 @@ If you do not want to expose the SDK key or the content of the config JSON file,
 
 Also, we recommend using [confidential targeting comparators](../advanced/targeting.mdx#confidential-text-comparators) in the Targeting Rules of those feature flags that are used in the frontend/mobile SDKs.
 
-## Sample App {#sample-apps}
+## Sample App {/* #sample-apps */}
 
 <a href="https://github.com/configcat/android-sdk/tree/master/samples" target="_blank">Android App with auto polling and change listener</a>
 

--- a/website/versioned_docs/version-V1/sdk-reference/dotnet.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/dotnet.mdx
@@ -164,7 +164,7 @@ It is important to provide an argument for the `defaultValue` parameter, specifi
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`                |
 | -------------- | --------------------------------- |
@@ -195,7 +195,7 @@ var value = client.GetValue("keyOfMyDecimalSetting", 0d);
 var value = client.GetValue<double>("keyOfMyDecimalSetting", 0);
 ```
 
-## Anatomy of `GetValueDetails()`, `GetValueDetailsAsync()` {#anatomy-of-getvaluedetails}
+## Anatomy of `GetValueDetails()`, `GetValueDetailsAsync()` {/* #anatomy-of-getvaluedetails */}
 
 `GetValueDetails()`/`GetValueDetailsAsync()` are similar to `GetValue()`/`GetValueAsync()` but instead of returning the evaluated value only, they provide more detailed information about the evaluation result.
 

--- a/website/versioned_docs/version-V1/sdk-reference/elixir.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/elixir.mdx
@@ -108,7 +108,7 @@ value = ConfigCat.get_value(
 )
 ```
 
-## Anatomy of `get_value_details()` {#anatomy-of-getvaluedetails}
+## Anatomy of `get_value_details()` {/* #anatomy-of-getvaluedetails */}
 
 `get_value_details()` is similar to `get_value()` but instead of returning the evaluated value only, it gives more detailed information about the evaluation result.
 

--- a/website/versioned_docs/version-V1/sdk-reference/java.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/java.mdx
@@ -158,7 +158,7 @@ It is important to provide an argument for the `classOfT` parameter, specificall
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`    |
 | -------------- |-----------------------|

--- a/website/versioned_docs/version-V1/sdk-reference/js-ssr.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/js-ssr.mdx
@@ -179,7 +179,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/versioned_docs/version-V1/sdk-reference/js.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/js.mdx
@@ -201,7 +201,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/versioned_docs/version-V1/sdk-reference/node.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/node.mdx
@@ -184,7 +184,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |

--- a/website/versioned_docs/version-V1/sdk-reference/python.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/python.mdx
@@ -119,7 +119,7 @@ value = client.get_value(
 )
 ```
 
-## Anatomy of `get_value_details()` {#anatomy-of-getvaluedetails}
+## Anatomy of `get_value_details()` {/* #anatomy-of-getvaluedetails */}
 
 `get_value_details()` is similar to `get_value()` but instead of returning the evaluated value only, it gives an _EvaluationDetails_ 
 object with more detailed information about the evaluation result.

--- a/website/versioned_docs/version-V1/sdk-reference/react.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/react.mdx
@@ -199,7 +199,7 @@ It is important to provide an argument for the `defaultValue` parameter that mat
 Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | `typeof defaultValue` |
 | -------------- | --------------------- |
@@ -624,7 +624,7 @@ useEffect(() => {
 });
 ```
 
-## SDK Hooks (not React Hooks) {#hooks}
+## SDK Hooks (not React Hooks) {/* #hooks */}
 
 > ** _ConfigCat SDK_ hooks are different than React Hooks. **
 

--- a/website/versioned_docs/version-V1/sdk-reference/ruby.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/ruby.mdx
@@ -119,7 +119,7 @@ value = client.get_value(
 );
 ```
 
-## Anatomy of `get_value_details` {#anatomy-of-getvaluedetails}
+## Anatomy of `get_value_details` {/* #anatomy-of-getvaluedetails */}
 
 `get_value_details` is similar to `get_value` but instead of returning the evaluated value only, it gives an _EvaluationDetails_
 object with more detailed information about the evaluation result.

--- a/website/versioned_docs/version-V1/sdk-reference/rust.mdx
+++ b/website/versioned_docs/version-V1/sdk-reference/rust.mdx
@@ -132,7 +132,7 @@ It is important to provide an argument for the `default` parameter, specifically
 that matches the type of the feature flag or setting you are evaluating. Please refer to the following table for the corresponding types.
 :::
 
-### Setting type mapping {#setting-type-mapping}
+### Setting type mapping {/* #setting-type-mapping */}
 
 | Setting Kind   | Type parameter `T`      |
 | -------------- | ----------------------- |


### PR DESCRIPTION
### Describe the purpose of your pull request
Recent version upgrades broke syntax highlighting and code navigation in .mdx files. This PR aims to fix this.

See also: https://docusaurus.io/docs/next/markdown-features/toc#heading-ids

(The failure of the "Validate Document" check is expected. The Android SDK references use an unexpected heading structure, which is not related to this PR.)

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
Nothing to test, only development tooling configuration has been changed.

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [ ] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
