### PR TITLE
add claude code instructions to mcp server docs page

### DIFF
--- a/website/docs/advanced/mcp-server.mdx
+++ b/website/docs/advanced/mcp-server.mdx
@@ -96,6 +96,32 @@ You can start writing prompts into Cursor's AI panel.
 </Step>
 </Steps>
 </TabItem>
+<TabItem value="claudecode" label="Claude Code" default>
+<Steps>
+<Step>
+Install [Claude Code](https://claude.com/product/claude-code)
+</Step>
+<Step>
+Add ConfigCat MCP server to Claude Code from your terminal:
+
+```bash
+claude mcp add --env CONFIGCAT_API_USER=YOUR_API_USER  \
+  --env CONFIGCAT_API_PASS=YOUR_API_PASSWORD \
+  --transport stdio ConfigCat -- npx -y @configcat/mcp-server
+```
+
+</Step>
+<Step>
+Start Claude Code with the `claude` command.
+</Step>
+<Step>
+Check the ConfigCat MCP server with the `/mcp` command in Claude Code. The connected ConfigCat server should appear in the Local MCPs list.
+</Step>
+<Step>
+You can now start writing prompts in Claude Code.
+</Step>
+</Steps>
+</TabItem>
 <TabItem value="vscode" label="Visual Studio Code">
 <Steps>
 <Step>


### PR DESCRIPTION
### Describe the purpose of your pull request
- add claude code instructions to mcp server docs page

### How to test? (only if applicable)
- check the mcp docs page: `docs/advanced/mcp-server/`
- try to add claude code mcp server instructions

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [x] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [x] I have added my changes to the V1 and V2 documentations.
