### PR TITLE
Simplify MCP server command in documentation

### DIFF
--- a/website/docs/advanced/mcp-server.mdx
+++ b/website/docs/advanced/mcp-server.mdx
@@ -105,9 +105,7 @@ Install [Claude Code](https://claude.com/product/claude-code)
 Add ConfigCat MCP server to Claude Code from your terminal:
 
 ```bash
-claude mcp add --env CONFIGCAT_API_USER=YOUR_API_USER  \
-  --env CONFIGCAT_API_PASS=YOUR_API_PASSWORD \
-  --transport stdio ConfigCat -- npx -y @configcat/mcp-server
+claude mcp add --env CONFIGCAT_API_USER=YOUR_API_USER --env CONFIGCAT_API_PASS=YOUR_API_PASSWORD --transport stdio ConfigCat -- npx -y @configcat/mcp-server
 ```
 
 </Step>


### PR DESCRIPTION
\ is not working on windows cmd

### How to test? (only if applicable)
- Check the mcp server docs page

### Requirement checklist
- [x] I have validated my changes on a test/local environment.
- [x] I have tested that the code snippets I added work. (Leave unchecked if there are no new code snippets.)
- [ ] I have added my changes to the V1 and V2 documentations.
